### PR TITLE
Implement Email Template Builder with CRUD, Export, and Section Types

### DIFF
--- a/builder/admin-page.php
+++ b/builder/admin-page.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Admin Page for Email Template Builder.
+ * Handles the registration of the admin menu and renders the builder page.
+ *
+ * @package EmailTemplateBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Adds the top-level admin menu page for the Email Template Builder.
+ *
+ * This function registers the main menu item that users will click to access
+ * the email template builder interface.
+ *
+ * @since 1.0.0
+ */
+function etb_add_admin_menu_page() {
+	add_menu_page(
+		__( 'Email Template Builder', 'email-template-builder' ), // Page title that appears in <title> tag
+		__( 'Email Templates', 'email-template-builder' ),    // Menu title
+		'manage_options', // Capability required to see this menu
+		'etb-builder',    // Menu slug
+		'etb_render_builder_page', // Function to display the page content
+		'dashicons-email-alt2', // Icon URL (or Dashicon class)
+		30 // Position in the menu order
+	);
+}
+add_action( 'admin_menu', 'etb_add_admin_menu_page' );
+
+/**
+ * Renders the Email Template Builder page content.
+ *
+ * This function acts as a router based on the 'action' query parameter.
+ * It can display a list of existing templates (using WP_List_Table),
+ * or the main builder interface for creating/editing a template.
+ * Data for the Alpine.js component is prepared and JSON-encoded here.
+ *
+ * @since 1.0.0
+ * @global string $action Current action derived from query parameters.
+ * @global int    $template_id Current template ID if editing/cloning.
+ */
+function etb_render_builder_page() {
+    // Determine current action (list, edit, add_new, clone)
+    $action = isset( $_GET['action'] ) ? sanitize_key( $_GET['action'] ) : 'list';
+    $template_id = isset( $_GET['template_id'] ) ? absint( $_GET['template_id'] ) : 0;
+
+    $initial_template_data = array(); // Initialize to ensure it's always an array
+
+    // Prepare data for the Alpine.js component based on action
+    if ( $action === 'edit' && $template_id ) {
+        $post = get_post( $template_id );
+        if ($post && $post->post_type === 'email_template') {
+            $template_structure_json = get_post_meta($template_id, '_template_structure', true);
+            $sections = !empty($template_structure_json) ? json_decode($template_structure_json, true) : array();
+            if (json_last_error() !== JSON_ERROR_NONE) $sections = array(); // Reset if JSON is invalid
+
+            $initial_template_data = array(
+                'id' => $template_id,
+                'title' => $post->post_title,
+                'sections' => $sections,
+            );
+        } else {
+            // Invalid template ID or post type, redirect to list or show error
+            echo '<div class="notice notice-error"><p>' . esc_html__('Error: Template not found or invalid ID.', 'email-template-builder') . '</p></div>';
+            $action = 'list'; // Fallback to list view
+        }
+    } elseif ($action === 'add_new') {
+        // Default structure for a new template
+        $initial_template_data = array(
+            'id' => null, // No ID for new template
+            'title' => 'New Email Template',
+            'sections' => array(
+                array(
+                    'id' => 'section_' . uniqid(),
+                    'type' => 'text',
+                    'content' => array(
+                        'en' => 'This is a default text block.',
+                        'pt' => 'Este é um bloco de texto padrão.',
+                        'es' => 'Este es un bloque de texto predeterminado.',
+                    ),
+                ),
+            ),
+        );
+    } elseif ($action === 'clone' && $template_id) {
+        $post = get_post($template_id);
+        if ($post && $post->post_type === 'email_template') {
+            $template_structure_json = get_post_meta($template_id, '_template_structure', true);
+            $sections = !empty($template_structure_json) ? json_decode($template_structure_json, true) : array();
+            if (json_last_error() !== JSON_ERROR_NONE) $sections = array();
+
+            $initial_template_data = array(
+                'id' => null, // Crucial: No ID, so it's treated as new
+                'title' => sprintf(esc_html__('Copy of %s', 'email-template-builder'), $post->post_title),
+                'sections' => $sections, // Keep the sections
+            );
+            // Force action to 'add_new' effectively, but with pre-filled data
+            // The rest of the builder UI rendering path will handle this as a new template
+        } else {
+            echo '<div class="notice notice-error"><p>' . esc_html__('Error: Template to clone not found or invalid ID.', 'email-template-builder') . '</p></div>';
+            $action = 'list'; // Fallback to list view
+        }
+    }
+
+
+    if ($action === 'list'):
+        // Display list of templates
+        if ( ! class_exists( 'ETB_Templates_List_Table' ) ) {
+            require_once dirname( __FILE__ ) . '/class-etb-templates-list-table.php';
+        }
+        $list_table = new ETB_Templates_List_Table();
+        $list_table->prepare_items();
+        ?>
+        <div class="wrap">
+            <h1 class="wp-heading-inline"><?php esc_html_e('Email Templates', 'email-template-builder'); ?></h1>
+            <a href="<?php echo esc_url(admin_url('admin.php?page=etb-builder&action=add_new')); ?>" class="page-title-action"><?php esc_html_e('Add New', 'email-template-builder'); ?></a>
+            <form method="post" id="etb-list-table-form">
+                <?php // The nonce for bulk actions is usually handled by WP_List_Table itself if form is present ?>
+                <?php
+                $list_table->display();
+                ?>
+            </form>
+        </div>
+        <?php
+        // Enqueue WP List Table scripts and styles if not already done by WP core for this screen
+        // Usually, this is handled automatically when extending WP_List_Table.
+        return; // Stop further rendering if we are in list view
+    endif;
+
+    // If we are here, it's 'edit' or 'add_new' action, so render the builder UI
+    $template_data_json = htmlspecialchars(wp_json_encode($initial_template_data), ENT_QUOTES, 'UTF-8');
+
+    // Define dynamic variables
+    $dynamic_variables = array('{{name}}', '{{email}}', '{{company_name}}', '{{event_date}}', '{{booking_id}}', '{{phone}}', '{{custom_note}}');
+
+    // Get translatable labels using the helper function
+    $translatable_labels_raw = etb_get_translatable_labels_config();
+    $translatable_snippets_for_select = array();
+    foreach ($translatable_labels_raw as $key => $translations) {
+        $translatable_snippets_for_select[$key] = isset($translations['en']) ? $translations['en'] . " ({{snippet:$key}})" : "Snippet: $key ({{snippet:$key}})";
+    }
+    ?>
+    <div class="wrap etb-wrap" x-data="emailTemplateBuilder(<?php echo $template_data_json; ?>)">
+        <h1>
+            <?php echo $initial_template_data['id'] ? esc_html__('Edit Email Template', 'email-template-builder') : esc_html__('Add New Email Template', 'email-template-builder'); ?>
+            <a href="<?php echo esc_url(admin_url('admin.php?page=etb-builder')); ?>" class="page-title-action"><?php esc_html_e('Back to List', 'email-template-builder'); ?></a>
+        </h1>
+
+        <?php
+        // Display "Last edited by" information if editing an existing template
+        if ( $action === 'edit' && isset($post) && $post ) {
+            $last_editor_id = get_post_meta( $post->ID, '_edit_last', true );
+            $last_modified_time = get_the_modified_time( __('Y/m/d g:i:s a'), $post ); // Get formatted time
+
+            if ( $last_editor_id ) {
+                $editor = get_userdata( $last_editor_id );
+                if ( $editor ) {
+                    printf(
+                        '<p class="etb-last-edited-notice"><small>%s</small></p>',
+                        sprintf(
+                            esc_html__( 'Last edited by %1$s on %2$s.', 'email-template-builder' ),
+                            esc_html( $editor->display_name ),
+                            esc_html( $last_modified_time )
+                        )
+                    );
+                }
+            }
+        }
+        ?>
+
+        <div class="etb-top-actions">
+            <label for="etb-template-title"><?php esc_html_e('Template Name:', 'email-template-builder'); ?></label>
+            <input type="text" id="etb-template-title" x-model="template.title" style="min-width: 300px;">
+            <button class="button button-primary" @click="saveTemplate" :disabled="isLoading">
+                <span x-show="!isLoading"><?php esc_html_e('Save Template', 'email-template-builder'); ?></span>
+                <span x-show="isLoading"><?php esc_html_e('Saving...', 'email-template-builder'); ?></span>
+            </button>
+            <button class="button" @click="exportCurrentLanguageHTML" :disabled="!template.id"><?php esc_html_e('Export HTML (Current Lang)', 'email-template-builder'); ?></button>
+            <button class="button" @click="resetToLastSaved" :disabled="!template.id"><?php esc_html_e('Reset to Last Saved', 'email-template-builder'); ?></button>
+        </div>
+
+        <div id="etb-builder-ui" class="etb-builder-ui" x-show="template">
+            <div class="etb-sidebar">
+                <h2><?php esc_html_e('Controls', 'email-template-builder'); ?></h2>
+
+                <div>
+                    <h3><?php esc_html_e('Add New Section', 'email-template-builder'); ?></h3>
+                    <div class="etb-add-section-buttons">
+                        <button class="button" @click="addSection('text')"><span class="dashicons dashicons-editor-paragraph"></span> <?php esc_html_e('Text', 'email-template-builder'); ?></button>
+                        <button class="button" @click="addSection('image')"><span class="dashicons dashicons-format-image"></span> <?php esc_html_e('Image', 'email-template-builder'); ?></button>
+                        <button class="button" @click="addSection('button')"><span class="dashicons dashicons-button"></span> <?php esc_html_e('Button', 'email-template-builder'); ?></button>
+                        <button class="button" @click="addSection('divider')"><span class="dashicons dashicons-minus"></span> <?php esc_html_e('Divider', 'email-template-builder'); ?></button>
+                    </div>
+                </div>
+                <hr>
+                 <div x-data="{ expanded: true }" class="etb-sidebar-group">
+                    <h3 @click="expanded = !expanded">
+                        <?php esc_html_e('Dynamic Variables', 'email-template-builder'); ?>
+                        <span x-show="expanded" class="dashicons dashicons-arrow-up-alt2"></span>
+                        <span x-show="!expanded" class="dashicons dashicons-arrow-down-alt2"></span>
+                    </h3>
+                    <div x-show="expanded" class="etb-sidebar-collapsible">
+                        <p><small><?php esc_html_e('Click a variable to copy. Then paste into a text field.', 'email-template-builder'); ?></small></p>
+                        <ul class="etb-variables-list">
+                            <?php foreach ($dynamic_variables as $var) : ?>
+                                <li @click="copyToClipboard('<?php echo esc_js($var); ?>')" title="<?php esc_attr_e('Click to copy', 'email-template-builder'); ?>"><code><?php echo esc_html($var); ?></code></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                </div>
+                <hr>
+                 <div x-data="{ expanded: true }" class="etb-sidebar-group">
+                    <h3 @click="expanded = !expanded">
+                        <?php esc_html_e('Translatable Snippets', 'email-template-builder'); ?>
+                        <span x-show="expanded" class="dashicons dashicons-arrow-up-alt2"></span>
+                        <span x-show="!expanded" class="dashicons dashicons-arrow-down-alt2"></span>
+                    </h3>
+                     <div x-show="expanded" class="etb-sidebar-collapsible">
+                        <p><small><?php esc_html_e('Select a snippet to insert its placeholder into the active text area.', 'email-template-builder'); ?></small></p>
+                        <select @change="insertText($event.target.value); $event.target.value=''">
+                            <option value=""><?php esc_html_e('-- Select Snippet --', 'email-template-builder'); ?></option>
+                            <?php foreach ($translatable_snippets_for_select as $key => $display_text) : ?>
+                                <option value="{{snippet:<?php echo esc_attr($key); ?>}}"><?php echo esc_html($display_text); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                </div>
+                <hr>
+                <h3><?php esc_html_e('Template Sections', 'email-template-builder'); ?></h3>
+                <div id="etb-sections-list" class="etb-sections-list">
+                    <template x-for="(section, index) in template.sections" :key="section.id">
+                        <div class="etb-section" :data-id="section.id" :class="'etb-section-type-' + section.type">
+                            <div class="etb-section-header">
+                                <span class="etb-section-icon" :class="getSectionIconClass(section.type)" :title="getSectionTypeTitle(section.type)"></span>
+                                <span x-text="getSectionTitle(section)" class="etb-section-title-text"></span>
+                                <div class="etb-section-actions">
+                                    <button class="etb-section-action-btn" @click="removeSection(index)" title="<?php esc_attr_e('Remove Section', 'email-template-builder'); ?>"><span class="dashicons dashicons-trash"></span></button>
+                                    <!-- Add clone section button here if desired -->
+                                </div>
+                            </div>
+                            <div class="etb-section-content">
+                                <!-- Text Section -->
+                                <div x-show="section.type === 'text'">
+                                    <label><?php esc_html_e('Text Content:', 'email-template-builder'); ?></label>
+                                    <textarea x-model="section.content[currentLang]" @focus="setActiveTextarea($event.target)" style="width: 100%; min-height: 100px;"></textarea>
+                                </div>
+
+                                <!-- Image Section -->
+                                <div x-show="section.type === 'image'">
+                                    <label :for="'img-url-' + section.id + '-' + currentLang"><?php esc_html_e('Image URL:', 'email-template-builder'); ?> (<span x-text="currentLang.toUpperCase()"></span>)</label>
+                                    <input type="url" :id="'img-url-' + section.id + '-' + currentLang" x-model="section.content.url[currentLang]" style="width:100%;">
+
+                                    <label :for="'img-alt-' + section.id + '-' + currentLang"><?php esc_html_e('Alt Text:', 'email-template-builder'); ?> (<span x-text="currentLang.toUpperCase()"></span>)</label>
+                                    <input type="text" :id="'img-alt-' + section.id + '-' + currentLang" x-model="section.content.alt[currentLang]" style="width:100%;">
+                                </div>
+
+                                <!-- Button Section -->
+                                <div x-show="section.type === 'button'">
+                                    <label :for="'btn-text-' + section.id + '-' + currentLang"><?php esc_html_e('Button Text:', 'email-template-builder'); ?> (<span x-text="currentLang.toUpperCase()"></span>)</label>
+                                    <input type="text" :id="'btn-text-' + section.id + '-' + currentLang" x-model="section.content.text[currentLang]" @focus="setActiveTextarea($event.target)" style="width:100%;">
+
+                                    <label :for="'btn-url-' + section.id + '-' + currentLang"><?php esc_html_e('Button URL:', 'email-template-builder'); ?> (<span x-text="currentLang.toUpperCase()"></span>)</label>
+                                    <input type="url" :id="'btn-url-' + section.id + '-' + currentLang" x-model="section.content.url[currentLang]" style="width:100%;">
+
+                                    <label :for="'btn-bgcolor-' + section.id"><?php esc_html_e('Background Color:', 'email-template-builder'); ?></label>
+                                    <input type="color" :id="'btn-bgcolor-' + section.id" x-model="section.content.bgColor" style="width:100px; height: 30px;">
+                                </div>
+
+                                <!-- Divider Section (No editable content) -->
+                                <div x-show="section.type === 'divider'">
+                                    <p style="text-align:center; color:#777; font-style:italic;"><?php esc_html_e('Visual Divider', 'email-template-builder'); ?></p>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+                <p x-show="template.sections.length === 0"><?php esc_html_e('No sections yet. Add one above!', 'email-template-builder'); ?></p>
+            </div>
+            <div class="etb-main-content">
+                <div class="etb-preview-tabs">
+                    <button :class="{'active': currentLang === 'en'}" @click="switchLang('en')"><?php esc_html_e('English (EN)', 'email-template-builder'); ?></button>
+                    <button :class="{'active': currentLang === 'pt'}" @click="switchLang('pt')"><?php esc_html_e('Portuguese (PT)', 'email-template-builder'); ?></button>
+                    <button :class="{'active': currentLang === 'es'}" @click="switchLang('es')"><?php esc_html_e('Spanish (ES)', 'email-template-builder'); ?></button>
+                </div>
+                <div class="etb-preview-iframe-container">
+                    <iframe x-ref="previewIframe" style="width: 100%; height: 500px; border: 1px solid #ccc;"></iframe>
+                </div>
+            </div>
+        </div>
+        <?php /* Inline styles removed, will be enqueued from admin-builder.css */ ?>
+    </div>
+    <?php
+}
+
+/**
+ * Enqueues scripts and styles for the Email Template Builder admin page.
+ *
+ * This function ensures that Alpine.js, jQuery UI Sortable, the custom builder
+ * JavaScript, and the builder's CSS are loaded only on the relevant admin page.
+ * It also localizes data for the JavaScript, including nonces and configuration.
+ *
+ * @since 1.0.0
+ * @param string $hook_suffix The hook suffix of the current admin page.
+ */
+function etb_enqueue_builder_assets( $hook_suffix ) {
+	// Determine if we are on the main builder page or a subpage action (edit, add_new).
+    // The hook for top-level pages is 'toplevel_page_{menu_slug}'.
+    // For pages added via add_submenu_page, it might be '{parent_slug}_page_{menu_slug}'.
+    // Since we use one callback for list/edit/add, 'toplevel_page_etb-builder' should cover all.
+	$current_screen = get_current_screen();
+    if ( 'toplevel_page_etb-builder' !== $current_screen->id ) {
+        return;
+    }
+
+    // Enqueue main builder stylesheet.
+    wp_enqueue_style(
+        'etb-admin-builder-style', // Handle for the stylesheet.
+        get_template_directory_uri() . '/builder/assets/css/admin-builder.css', // Path to CSS file.
+        array(), // Dependencies.
+        filemtime( get_template_directory() . '/builder/assets/css/admin-builder.css' ) // Versioning.
+    );
+
+	// Enqueue Alpine.js from a CDN.
+	wp_enqueue_script(
+		'alpinejs', // Handle.
+		'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js', // Source.
+		array(), // No dependencies.
+		'3.13.10', // Version.
+		true // Load in footer.
+	);
+
+	// Enqueue jQuery UI Sortable (WordPress includes jQuery and jQuery UI Core by default).
+    wp_enqueue_script('jquery-ui-sortable');
+
+	// Builder specific script (Alpine.js component logic).
+	wp_enqueue_script(
+		'etb-builder-script', // Handle.
+		get_template_directory_uri() . '/builder/assets/js/builder.js', // Path to JS file.
+		array( 'alpinejs', 'jquery-ui-sortable', 'wp-api-fetch' ), // Dependencies.
+		filemtime( get_template_directory() . '/builder/assets/js/builder.js' ), // Versioning.
+		true // Load in footer.
+	);
+
+	// Localize script with data for JavaScript.
+    $translatable_labels_raw = etb_get_translatable_labels_config();
+	wp_localize_script(
+        'etb-builder-script', // Script handle to attach data to.
+        'etb_data',          // Object name in JavaScript.
+        array(
+            'nonce'                       => wp_create_nonce( 'wp_rest' ), // Nonce for REST API.
+            'export_nonce'                => wp_create_nonce( 'etb_export_template_html_nonce' ), // Nonce for export action.
+            'admin_url'                   => admin_url( 'admin.php' ), // Base URL for admin actions.
+            'base_url'                    => rest_url(), // Base URL for REST API.
+            'translatable_snippets_full'  => $translatable_labels_raw, // Full translations for JS.
+        )
+    );
+}
+add_action( 'admin_enqueue_scripts', 'etb_enqueue_builder_assets' );
+
+?>

--- a/builder/assets/css/admin-builder.css
+++ b/builder/assets/css/admin-builder.css
@@ -1,0 +1,217 @@
+/* Email Template Builder Admin Styles */
+
+.etb-wrap {
+    margin-top: 20px;
+}
+
+.etb-top-actions {
+    margin-bottom: 20px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+.etb-top-actions label {
+    font-weight: bold;
+}
+
+.etb-builder-ui {
+    display: flex;
+    margin-top: 20px;
+    gap: 20px;
+}
+
+.etb-sidebar {
+    width: 380px; /* Slightly wider for new elements */
+    padding: 20px;
+    background-color: #f0f0f1;
+    border-right: 1px solid #c3c4c7;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    max-height: calc(100vh - 200px); /* Adjust based on WP header/footer height */
+    overflow-y: auto;
+}
+.etb-sidebar h2 {
+    margin-top: 0;
+    font-size: 1.2em;
+}
+.etb-sidebar h3 {
+    font-size: 1em;
+    margin: 0 0 10px 0;
+    padding: 0;
+}
+
+.etb-add-section-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px; /* Smaller gap for compact buttons */
+}
+.etb-add-section-buttons .button .dashicons {
+    margin-right: 5px;
+    vertical-align: text-bottom;
+}
+
+.etb-sidebar-group h3 {
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 1em;
+    margin: 0 0 10px 0;
+    padding: 8px;
+    background: #e0e0e0; /* Slightly darker than sidebar bg */
+    border-radius: 3px;
+    user-select: none;
+}
+.etb-sidebar-group h3:hover {
+    background: #d5d5d5;
+}
+.etb-sidebar-group h3 .dashicons {
+    font-size: 16px; /* Smaller arrow */
+}
+.etb-sidebar-collapsible {
+    padding-left: 10px;
+    border-left: 3px solid #c3c4c7;
+    margin-bottom: 15px;
+    font-size: 0.9em;
+}
+.etb-sidebar-collapsible p small {
+    color: #50575e;
+}
+
+.etb-variables-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 5px 0 0 0;
+}
+.etb-variables-list li {
+    padding: 4px 6px;
+    cursor: pointer;
+    border-radius: 3px;
+    margin-bottom: 4px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    transition: background-color 0.2s;
+}
+.etb-variables-list li:hover {
+    background-color: #e9f5ff;
+    border-color: #78c8f7;
+}
+.etb-variables-list code {
+    font-family: monospace;
+    background: none;
+}
+
+#etb-sections-list .etb-section {
+    border: 1px solid #ccd0d4;
+    margin-bottom: 10px;
+    background: #fff;
+    border-radius: 3px;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+}
+.etb-section-header {
+    padding: 10px 12px; /* Increased padding */
+    background: #f6f7f7; /* Lighter header */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: move;
+    border-bottom: 1px solid #e0e0e0;
+}
+.etb-section-header .etb-section-icon {
+    margin-right: 8px;
+    color: #50575e;
+    font-size: 18px; /* Slightly larger icon */
+}
+.etb-section-header .etb-section-title-text {
+    flex-grow: 1;
+    font-weight: 600; /* Bolder title text */
+    font-size: 13px;
+    color: #1d2327;
+}
+.etb-section-actions .etb-section-action-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #787c82;
+    padding: 0 3px;
+    vertical-align: middle;
+}
+.etb-section-actions .etb-section-action-btn:hover {
+    color: #d63638; /* Red for delete */
+}
+.etb-section-actions .etb-section-action-btn .dashicons {
+    font-size: 18px;
+}
+
+.etb-section-content {
+    padding: 15px;
+}
+.etb-section-content label {
+    display: block;
+    margin: 0 0 5px 0; /* Adjusted margin */
+    font-weight: bold;
+    font-size: 13px;
+    color: #3c434a;
+}
+.etb-section-content input[type="text"],
+.etb-section-content input[type="url"],
+.etb-section-content input[type="color"],
+.etb-section-content textarea,
+.etb-sidebar select { /* Apply to select in sidebar too */
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 12px; /* Increased margin */
+    border: 1px solid #8c8f94; /* Standard WP border */
+    border-radius: 3px;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,.07);
+    box-sizing: border-box; /* Important for 100% width */
+}
+.etb-section-content input[type="color"] {
+    height: 40px; /* Better height for color picker */
+    padding: 5px; /* Adjust padding for color picker */
+}
+
+
+.etb-main-content {
+    flex-grow: 1;
+    padding: 0px 20px 20px 0px; /* Original padding */
+}
+.etb-preview-tabs {
+    margin-bottom: 0;
+}
+.etb-preview-tabs button {
+    padding: 10px 15px;
+    border: 1px solid #c3c4c7;
+    background-color: #f0f0f1; /* Match sidebar bg */
+    cursor: pointer;
+    border-bottom: none;
+    position: relative;
+    top: 1px;
+    margin-right: -1px; /* Overlap borders */
+}
+.etb-preview-tabs button.active {
+    background-color: #f7f7f7; /* Match iframe container background */
+    border-top: 2px solid #2271b1; /* WP blue for active tab */
+    font-weight: bold;
+}
+.etb-preview-iframe-container {
+    border: 1px solid #c3c4c7;
+    background-color: #f7f7f7;
+    padding: 0;
+    margin-top: -1px; /* Connect with tabs */
+}
+.etb-preview-iframe-container iframe {
+    display: block;
+    width: 100%; /* Ensure iframe takes full width of container */
+    /* height is set inline for now, can be moved here */
+}
+
+/* WP List Table specific overrides if needed, e.g. for row actions */
+/* .wp-list-table .row-actions a { ... } */
+
+hr {
+    border: none;
+    border-top: 1px solid #ddd;
+    margin: 20px 0;
+}

--- a/builder/assets/js/builder.js
+++ b/builder/assets/js/builder.js
@@ -1,0 +1,467 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.data('emailTemplateBuilder', (initialTemplateData) => ({
+        initialDataSnapshot: null, // To store the initial state for reset
+        template: null, // Will be initialized in init
+        currentLang: 'en', // Default language
+        activeTextarea: null, // To keep track of the focused textarea for insertions
+        isLoading: false, // To provide UI feedback during save
+
+        init() {
+            this.template = JSON.parse(JSON.stringify(initialTemplateData)); // Deep copy
+            this.initialDataSnapshot = JSON.parse(JSON.stringify(initialTemplateData)); // Store snapshot for reset
+
+            const sectionsList = document.getElementById('etb-sections-list');
+            if (sectionsList) {
+                $(sectionsList).sortable({
+                    handle: '.etb-section-header',
+                    update: (event, ui) => {
+                        const sectionId = ui.item.data('id');
+                        const newIndex = ui.item.index();
+
+                        const originalIndex = this.template.sections.findIndex(s => s.id === sectionId);
+                        if (originalIndex !== -1) {
+                            const [movedSection] = this.template.sections.splice(originalIndex, 1);
+                            this.template.sections.splice(newIndex, 0, movedSection);
+                        }
+                        // Alpine should react to this change automatically
+                    }
+                }).disableSelection();
+            }
+
+            // Watch for changes in currentLang to potentially update previews or other elements
+            this.$watch('currentLang', (newLang, oldLang) => {
+                console.log(`Language switched from ${oldLang} to ${newLang}`);
+                // Any specific logic needed when language changes globally can go here
+            });
+
+            console.log('Email Template Builder initialized with Alpine.', this.template);
+            console.log('Translatable snippets available:', etb_data.translatable_snippets_full);
+        },
+
+        switchLang(lang) {
+            this.currentLang = lang;
+        },
+
+        addSection(type) {
+            let newSectionContent = {};
+            const defaultContent = { // For text-based properties
+                en: `New ${type} content (EN)`,
+                pt: `Novo conteúdo de ${type} (PT)`,
+                es: `Nuevo contenido de ${type} (ES)`
+            };
+
+            switch (type) {
+                case 'text':
+                    newSectionContent = { ...defaultContent };
+                    break;
+                case 'image':
+                    newSectionContent = {
+                        url: { en: '', pt: '', es: '' },
+                        alt: { en: '', pt: '', es: '' }
+                    };
+                    break;
+                case 'button':
+                    newSectionContent = {
+                        text: { ...defaultContent },
+                        url: { en: '#', pt: '#', es: '#' },
+                        bgColor: '#007bff' // Default button color
+                    };
+                    break;
+                case 'divider':
+                    newSectionContent = {}; // No content needed for divider
+                    break;
+                default:
+                    newSectionContent = { ...defaultContent };
+            }
+
+            const newSection = {
+                id: 'section_' + Date.now() + Math.random().toString(36).substring(2, 9),
+                type: type,
+                content: newSectionContent
+            };
+            this.template.sections.push(newSection);
+        },
+
+        removeSection(index) {
+            if (confirm('Are you sure you want to remove this section?')) {
+                this.template.sections.splice(index, 1);
+            }
+        },
+
+        getSectionTitle(section) {
+            const type = section.type;
+            // Attempt to get a snippet of text content if available
+            let previewText = '';
+            if (type === 'text' && section.content && section.content[this.currentLang]) {
+                previewText = section.content[this.currentLang].substring(0, 20);
+            } else if (type === 'button' && section.content && section.content.text && section.content.text[this.currentLang]) {
+                previewText = section.content.text[this.currentLang].substring(0, 20);
+            } else if (type === 'image' && section.content && section.content.url && section.content.url[this.currentLang]) {
+                previewText = section.content.url[this.currentLang].substring(0, 20);
+                 if(previewText.length == 20) previewText += '...';
+            }
+             if (previewText.length == 20 && type !== 'image') previewText += '...';
+
+
+            const typeName = this.getSectionTypeTitle(type);
+            return previewText ? `${typeName}: ${previewText}` : typeName;
+        },
+
+        getSectionTypeTitle(type) {
+            switch (type) {
+                case 'text': return 'Text';
+                case 'image': return 'Image';
+                case 'button': return 'Button';
+                case 'divider': return 'Divider';
+                default: return 'Section';
+            }
+        },
+
+        getSectionIconClass(type) {
+            switch (type) {
+                case 'text': return 'dashicons dashicons-editor-paragraph';
+                case 'image': return 'dashicons dashicons-format-image';
+                case 'button': return 'dashicons dashicons-button';
+                case 'divider': return 'dashicons dashicons-minus';
+                default: return 'dashicons dashicons-admin-generic';
+            }
+        },
+
+        setActiveTextarea(textareaElement) {
+            this.activeTextarea = textareaElement;
+        },
+
+        insertText(textToInsert) {
+            if (this.activeTextarea && textToInsert) {
+                const start = this.activeTextarea.selectionStart;
+                const end = this.activeTextarea.selectionEnd;
+                const currentVal = this.activeTextarea.value;
+                const newVal = currentVal.substring(0, start) + textToInsert + currentVal.substring(end);
+
+                this.activeTextarea.value = newVal; // Update the textarea/input value directly
+                // Dispatch an 'input' event to ensure Alpine.js's x-model picks up the change
+                this.activeTextarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+                // Restore focus and cursor position if possible
+                this.activeTextarea.focus();
+                this.$nextTick(() => {
+                    this.activeTextarea.selectionStart = this.activeTextarea.selectionEnd = start + textToInsert.length;
+                });
+            } else if (!this.activeTextarea && textToInsert) {
+                alert('Please click into a text area first to insert content.');
+            }
+        },
+
+        renderSectionPreview(section) {
+            let html = '';
+            const sContent = section.content || {}; // Ensure content object exists
+            const currentLang = this.currentLang;
+            const defaultLang = 'en';
+
+            // Helper to get localized content, falling back to defaultLang
+            const getLocalized = (obj, key) => {
+                if (obj && typeof obj === 'object' && obj[key] && typeof obj[key] === 'object') {
+                    return obj[key][currentLang] || obj[key][defaultLang] || '';
+                } else if (obj && typeof obj === 'object' && obj[currentLang]) { // For direct text content like in old text sections
+                     return obj[currentLang] || obj[defaultLang] || '';
+                }
+                return obj || ''; // Fallback for non-localized or simple string content
+            };
+
+            // Helper to process snippets and variables for a given text string
+            const processText = (text) => {
+                if (typeof text !== 'string') text = '';
+                // Snippets
+                text = text.replace(/\{\{snippet:([a-zA-Z0-9_]+)\}\}/g, (match, snippetKey) => {
+                    return (etb_data.translatable_snippets_full && etb_data.translatable_snippets_full[snippetKey] && etb_data.translatable_snippets_full[snippetKey][currentLang])
+                           ? etb_data.translatable_snippets_full[snippetKey][currentLang]
+                           : match;
+                });
+                // Variables
+                text = text.replace(/\{\{([a-zA-Z0-9_]+)\}\}/g, (match) => {
+                    const DUMMY_TEXT_COLOR = '#888';
+                    return `<span style="color: ${DUMMY_TEXT_COLOR}; font-family: monospace; background-color: #f0f0f0; padding: 1px 3px; border-radius: 3px;">${match.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</span>`;
+                });
+                return text;
+            };
+
+            const outerTableStyle = "border-bottom: 1px dashed #eee;"; // Mimics PHP export style for consistency
+            const textCellStyle = "padding: 10px; font-family: Arial, sans-serif; font-size: 14px; line-height: 1.5; color: #333;";
+
+
+            switch (section.type) {
+                case 'text':
+                    const text = processText(getLocalized(sContent, currentLang)); // sContent itself is the multilingual object for text
+                    html = `<table width="100%" border="0" cellpadding="0" cellspacing="0" style="${outerTableStyle}"><tr><td style="${textCellStyle}">${text.replace(/\n/g, '<br>\n')}</td></tr></table>`;
+                    break;
+                case 'image':
+                    const imageUrl = getLocalized(sContent.url, currentLang); // sContent.url is the multilingual object
+                    const altText = processText(getLocalized(sContent.alt, currentLang)); // sContent.alt is multilingual
+                    if (imageUrl) {
+                        html = `<table width="100%" border="0" cellpadding="0" cellspacing="0" style="${outerTableStyle}"><tr><td align="center" style="padding:10px;"><img src="${imageUrl}" alt="${altText}" style="display:block; max-width:100%; height:auto; border:0;" /></td></tr></table>`;
+                    } else {
+                        html = `<table width="100%" border="0" cellpadding="0" cellspacing="0" style="${outerTableStyle}"><tr><td style="${textCellStyle} text-align:center; color:#aaa;">[Image: No URL provided]</td></tr></table>`;
+                    }
+                    break;
+                case 'button':
+                    const buttonText = processText(getLocalized(sContent.text, currentLang));
+                    const buttonUrl = getLocalized(sContent.url, currentLang) || '#';
+                    const bgColor = sContent.bgColor || '#007bff';
+                    const buttonTdStyle = `background-color:${bgColor}; border-radius:5px; padding:10px 20px; text-align:center;`;
+                    const buttonLinkStyle = "font-family: Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; display:inline-block;";
+                    html = `<table width="100%" border="0" cellpadding="0" cellspacing="0" style="${outerTableStyle} text-align:center;"><tr><td align="center" style="padding:10px;"><table border="0" cellpadding="0" cellspacing="0"><tr><td style="${buttonTdStyle}"><a href="${buttonUrl}" target="_blank" style="${buttonLinkStyle}">${buttonText}</a></td></tr></table></td></tr></table>`;
+                    break;
+                case 'divider':
+                    const dividerStyle = "border-top:1px solid #dddddd; height:1px; margin:10px 0;";
+                    html = `<table width="100%" border="0" cellpadding="0" cellspacing="0" style="${outerTableStyle}"><tr><td style="padding:10px;"><div style="${dividerStyle}"></div></td></tr></table>`;
+                    break;
+                default:
+                    html = `<table width="100%" border="0" cellpadding="0" cellspacing="0" style="${outerTableStyle}"><tr><td style="${textCellStyle} color:red;">Unsupported section type: ${section.type}</td></tr></table>`;
+            }
+            return html;
+        },
+
+        copyToClipboard(text) {
+            if (!navigator.clipboard) {
+                // Fallback for older browsers
+                const textarea = document.createElement('textarea');
+                textarea.value = text;
+                document.body.appendChild(textarea);
+                textarea.select();
+                try {
+                    document.execCommand('copy');
+                    alert('Copied to clipboard (fallback): ' + text);
+                } catch (err) {
+                    alert('Failed to copy (fallback).');
+                }
+                document.body.removeChild(textarea);
+                return;
+            }
+            navigator.clipboard.writeText(text).then(() => {
+                alert('Copied to clipboard: ' + text);
+            }).catch(err => {
+                console.error('Failed to copy: ', err);
+                alert('Failed to copy.');
+            });
+        },
+
+        // This computed property will generate the full HTML for the preview iframe
+        get fullPreviewHTML() {
+            let bodyContent = this.template.sections.map(section => this.renderSectionPreview(section)).join('');
+            if (this.template.sections.length === 0) {
+                bodyContent = '<p style="text-align:center; color:#888; padding-top: 50px;">Preview will appear here as you add sections.</p>';
+            }
+
+            return `
+                <!DOCTYPE html>
+                <html lang="${this.currentLang}">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>Email Preview</title>
+                    <style>
+                        body { margin: 0; padding: 0; background-color: #f7f7f7; font-family: Arial, sans-serif; }
+                        .email-container { max-width: 600px; margin: 20px auto; background-color: #ffffff; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0,0,0,0.05); }
+                        /* Add more global email styles here if needed */
+                    </style>
+                </head>
+                <body>
+                    <div class="email-container">
+                        ${bodyContent}
+                    </div>
+                </body>
+                </html>
+            `;
+        },
+
+        updatePreviewIframe() {
+            const iframe = this.$refs.previewIframe;
+            if (iframe) {
+                iframe.srcdoc = this.fullPreviewHTML;
+            }
+        },
+
+        init() {
+            // ... (rest of init)
+            const sectionsList = document.getElementById('etb-sections-list');
+            if (sectionsList) {
+                $(sectionsList).sortable({
+                    handle: '.etb-section-header',
+                    update: (event, ui) => {
+                        const sectionId = ui.item.data('id');
+                        const newIndex = ui.item.index();
+
+                        const originalIndex = this.template.sections.findIndex(s => s.id === sectionId);
+                        if (originalIndex !== -1) {
+                            const [movedSection] = this.template.sections.splice(originalIndex, 1);
+                            this.template.sections.splice(newIndex, 0, movedSection);
+                        }
+                    }
+                }).disableSelection();
+            }
+
+            this.$watch('currentLang', (newLang, oldLang) => {
+                console.log(`Language switched from ${oldLang} to ${newLang}`);
+                this.updatePreviewIframe();
+            });
+
+            // Watch for any changes in template sections to update the iframe
+            // Deep watch template.sections array for changes in content
+             this.$watch('template.sections', (newSections, oldSections) => {
+                this.updatePreviewIframe();
+            }, { deep: true });
+
+
+            console.log('Email Template Builder initialized with Alpine.', this.template);
+            console.log('Translatable snippets available:', etb_data.translatable_snippets_full);
+
+            this.$nextTick(() => {
+                this.updatePreviewIframe(); // Initial iframe content
+            });
+        },
+
+        isLoading: false, // To provide UI feedback during save
+
+        saveTemplate() {
+            if (!this.template.title.trim()) {
+                alert('Please enter a template name.');
+                return;
+            }
+            this.isLoading = true;
+
+            const path = this.template.id ? `/wp/v2/email_template/${this.template.id}` : '/wp/v2/email_template';
+            const method = this.template.id ? 'PUT' : 'POST';
+
+            const dataToSave = {
+                title: this.template.title,
+                status: 'publish', // Or allow user to choose draft/publish
+                meta: {
+                    _template_structure: JSON.stringify(this.template.sections)
+                }
+            };
+
+            wp.apiFetch({
+                path: path,
+                method: method,
+                data: dataToSave,
+                headers: {
+                    'X-WP-Nonce': etb_data.nonce // This nonce is for the REST API
+                }
+            })
+            .then(response => {
+                console.log('Saved response:', response);
+                this.isLoading = false;
+                alert('Template saved successfully!');
+
+                if (response.id && !this.template.id) {
+                    this.template.id = response.id;
+                    // Update URL to reflect editing this template ID, so refresh works
+                    const newUrl = new URL(window.location.href);
+                    newUrl.searchParams.set('action', 'edit');
+                    newUrl.searchParams.set('template_id', response.id);
+                    window.history.pushState({path:newUrl.href}, '', newUrl.href);
+                }
+                 // After saving, we might want to refresh the list if the user goes back
+                // or update the current view if fields like "last modified" are shown.
+            })
+            .catch(error => {
+                this.isLoading = false;
+                console.error('Error saving template:', error);
+                let errorMessage = 'Error saving template.';
+                if (error.message) {
+                    errorMessage += ' ' + error.message;
+                }
+                if (error.code) {
+                     errorMessage += ` (Code: ${error.code})`;
+                }
+                alert(errorMessage);
+            });
+        },
+
+        exportCurrentLanguageHTML() {
+            if (!this.template.id) {
+                alert('Please save the template before exporting.');
+                return;
+            }
+            // Construct the URL for export
+            // We'll use admin_url for the base and add our own query parameters for a custom action.
+            // A dedicated admin action hook (admin_action_{action_name}) is cleaner than admin-post.
+            const exportUrl = new URL(etb_data.base_url.replace('/wp-json', '/wp-admin/admin.php')); // A bit hacky to get admin_url like this
+            exportUrl.searchParams.set('action', 'etb_export_template_html');
+            exportUrl.searchParams.set('template_id', this.template.id);
+            exportUrl.searchParams.set('lang', this.currentLang);
+            exportUrl.searchParams.set('_wpnonce', etb_data.export_nonce); // We'll need to add this nonce
+
+            window.open(exportUrl.toString(), '_blank');
+        },
+
+        resetToLastSaved() {
+            if (confirm('Are you sure you want to reset all changes to the last saved version?')) {
+                this.template = JSON.parse(JSON.stringify(this.initialDataSnapshot));
+                // After resetting, the preview needs to be updated
+                this.$nextTick(() => {
+                    this.updatePreviewIframe();
+                });
+                alert('Template has been reset to the last saved version.');
+            }
+        }
+    }));
+
+    // Handle delete links in the list table (if present on the page)
+    // This part is outside the Alpine component, runs once on DOMContentLoaded
+    document.addEventListener('DOMContentLoaded', () => {
+        const listTableForm = document.getElementById('etb-list-table-form');
+        if (listTableForm) {
+            listTableForm.addEventListener('click', function(event) {
+                if (event.target.classList.contains('etb-delete-template')) {
+                    event.preventDefault();
+                    if (confirm('Are you sure you want to delete this template? This action cannot be undone.')) {
+                        const templateId = event.target.dataset.id;
+                        const nonce = event.target.dataset.nonce; // This is the etb_delete_template_ nonce
+
+                        // We need the main REST API nonce for the header
+                        const restNonce = etb_data && etb_data.nonce ? etb_data.nonce : '';
+                        if (!restNonce) {
+                            alert('Security error: REST Nonce not found. Cannot delete template.');
+                            return;
+                        }
+
+                        // Note: The nonce on the link (etb_delete_template_) is for potential direct GET deletion or AJAX action handler.
+                        // For wp.apiFetch DELETE, the X-WP-Nonce header (etb_data.nonce) is the primary one.
+                        // We can still verify `nonce` if we had a custom AJAX action, but for REST API, it's less direct.
+                        // However, it's good practice to have it for non-JS fallback or if we decide to use an AJAX action.
+
+                        wp.apiFetch({
+                            path: `/wp/v2/email_template/${templateId}`,
+                            method: 'DELETE',
+                            headers: {
+                                'X-WP-Nonce': restNonce
+                            },
+                            // data: { // For DELETE, data is often not needed, but if force is required:
+                            //    force: true // To bypass trash
+                            // }
+                        })
+                        .then(response => {
+                            // console.log('Delete response:', response);
+                            alert('Template deleted successfully.');
+                            // Remove row from table or reload
+                            // event.target.closest('tr').remove(); // Simple removal
+                            location.reload(); // Easiest way to refresh list and pagination
+                        })
+                        .catch(error => {
+                            console.error('Error deleting template:', error);
+                            let errorMessage = 'Error deleting template.';
+                             if (error.message) {
+                                errorMessage += ' ' + error.message;
+                            }
+                            if (error.code) {
+                                errorMessage += ` (Code: ${error.code})`;
+                            }
+                            alert(errorMessage);
+                        });
+                    }
+                }
+            });
+        }
+    });
+});

--- a/builder/class-etb-templates-list-table.php
+++ b/builder/class-etb-templates-list-table.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * ETB_Templates_List_Table class.
+ *
+ * @package EmailTemplateBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+// WP_List_Table is not loaded automatically so we need to load it in our application
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * List table class for Email Templates.
+ */
+class ETB_Templates_List_Table extends WP_List_Table {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'singular' => __( 'Email Template', 'email-template-builder' ),
+				'plural'   => __( 'Email Templates', 'email-template-builder' ),
+				'ajax'     => false, // True if you want to load items via AJAX.
+			)
+		);
+	}
+
+	/**
+	 * Get a list of columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$columns = array(
+			'cb'    => '<input type="checkbox" />', // Checkbox for bulk actions.
+			'title' => __( 'Title', 'email-template-builder' ),
+			'date'  => __( 'Date', 'email-template-builder' ),
+		);
+		return $columns;
+	}
+
+	/**
+	 * Get a list of sortable columns.
+	 *
+	 * @return array
+	 */
+	public function get_sortable_columns() {
+		$sortable_columns = array(
+			'title' => array( 'title', true ), // True means it's sortable.
+			'date'  => array( 'date', false ),
+		);
+		return $sortable_columns;
+	}
+
+	/**
+	 * Get data for the table.
+	 *
+	 * @param int $per_page Number of items per page.
+	 * @param int $page_number Current page number.
+	 * @return array
+	 */
+	public function get_items_data( $per_page = 20, $page_number = 1 ) {
+		$args = array(
+			'post_type'      => 'email_template',
+			'posts_per_page' => $per_page,
+			'paged'          => $page_number,
+			'orderby'        => isset( $_REQUEST['orderby'] ) ? sanitize_key( $_REQUEST['orderby'] ) : 'date',
+			'order'          => isset( $_REQUEST['order'] ) ? strtoupper( sanitize_key( $_REQUEST['order'] ) ) : 'DESC',
+		);
+
+		$query = new WP_Query( $args );
+		$items = array();
+
+		if ( $query->have_posts() ) {
+			while ( $query->have_posts() ) {
+				$query->the_post();
+				$items[] = array(
+					'ID'    => get_the_ID(),
+					'title' => get_the_title(),
+					'date'  => get_the_date(),
+				);
+			}
+		}
+		wp_reset_postdata();
+		return $items;
+	}
+
+	/**
+	 * Handles the title column output.
+	 *
+	 * @param array $item The current item data.
+	 * @return string
+	 */
+	public function column_title( $item ) {
+		$page_slug = 'etb-builder'; // The slug for our admin page.
+
+		// Build edit/delete/clone actions.
+		$actions = array(
+			'edit'   => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( admin_url( 'admin.php?page=' . $page_slug . '&action=edit&template_id=' . $item['ID'] ) ),
+				__( 'Edit', 'email-template-builder' )
+			),
+			'delete' => sprintf(
+				'<a href="#" class="etb-delete-template" data-id="%d" data-nonce="%s">%s</a>',
+				absint( $item['ID'] ),
+                wp_create_nonce( 'etb_delete_template_' . $item['ID'] ),
+				__( 'Delete', 'email-template-builder' )
+			),
+            'clone' => sprintf(
+                '<a href="%s">%s</a>',
+                esc_url( admin_url( 'admin.php?page=' . $page_slug . '&action=clone&template_id=' . $item['ID'] ) ),
+                __( 'Clone', 'email-template-builder' )
+            ),
+		);
+
+		return sprintf( '<strong>%s</strong>%s', esc_html( $item['title'] ), $this->row_actions( $actions ) );
+	}
+
+
+	/**
+	 * Handles the checkbox column output.
+	 *
+	 * @param array $item The current item data.
+	 * @return string
+	 */
+	public function column_cb( $item ) {
+		return sprintf(
+			'<input type="checkbox" name="bulk-delete[]" value="%s" />',
+			$item['ID']
+		);
+	}
+
+	/**
+	 * Handles the default column output.
+	 *
+	 * @param array  $item The current item data.
+	 * @param string $column_name The current column name.
+	 * @return string
+	 */
+	public function column_default( $item, $column_name ) {
+		switch ( $column_name ) {
+			case 'date':
+				return esc_html( $item[ $column_name ] );
+			default:
+				return print_r( $item, true ); // Show the whole array for troubleshooting.
+		}
+	}
+
+	/**
+	 * Get bulk actions.
+	 *
+	 * @return array
+	 */
+	public function get_bulk_actions() {
+		$actions = array(
+			'bulk-delete' => __( 'Delete', 'email-template-builder' ),
+		);
+		return $actions;
+	}
+
+    /**
+	 * Process bulk actions.
+	 */
+	public function process_bulk_action() {
+        // Detect when a bulk action is being triggered...
+        if ( 'bulk-delete' === $this->current_action() ) {
+            $ids_to_delete = isset( $_POST['bulk-delete'] ) ? array_map( 'absint', $_POST['bulk-delete'] ) : array();
+            $nonce = isset( $_POST['_wpnonce'] ) ? sanitize_key( $_POST['_wpnonce'] ) : '';
+
+            if ( ! wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
+                 wp_die( 'Nonce verification failed for bulk delete!' );
+            }
+
+            if ( ! empty( $ids_to_delete ) ) {
+                foreach ( $ids_to_delete as $id ) {
+                    if ( current_user_can( 'delete_post', $id ) ) {
+                        wp_delete_post( $id, true ); // True to force delete, bypass trash.
+                    }
+                }
+                // Add admin notice for success/failure
+                add_action( 'admin_notices', function() {
+					echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Selected templates deleted.', 'email-template-builder' ) . '</p></div>';
+				});
+            }
+        }
+	}
+
+
+	/**
+	 * Prepare items for the table to display.
+	 */
+	public function prepare_items() {
+        $this->process_bulk_action(); // Process bulk actions first
+
+		$columns  = $this->get_columns();
+		$hidden   = array(); // Hidden columns.
+		$sortable = $this->get_sortable_columns();
+
+		$this->_column_headers = array( $columns, $hidden, $sortable );
+
+		$per_page     = $this->get_items_per_page( 'templates_per_page', 20 );
+		$current_page = $this->get_pagenum();
+		$total_items  = $this->get_total_items_count();
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+			)
+		);
+		$this->items = $this->get_items_data( $per_page, $current_page );
+	}
+
+	/**
+	 * Get the total number of items.
+	 *
+	 * @return int
+	 */
+	public function get_total_items_count() {
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'email_template',
+				'posts_per_page' => -1, // Count all.
+				'fields'         => 'ids', // Only get post IDs to optimize.
+			)
+		);
+		return $query->post_count;
+	}
+}
+?>

--- a/builder/export.php
+++ b/builder/export.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Handles HTML export of email templates.
+ *
+ * @package EmailTemplateBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+/**
+ * Action hook for handling the HTML export of an email template.
+ *
+ * This function is triggered by visiting `admin.php?action=etb_export_template_html`.
+ * It verifies nonce and user permissions, then fetches the template data,
+ * renders it into an HTML string using helper functions, and serves it as
+ * a downloadable HTML file.
+ *
+ * @since 1.0.0
+ * @uses etb_get_translatable_labels_config()
+ * @uses etb_render_section_for_export()
+ * @return void Outputs HTML file or dies with an error message.
+ */
+add_action( 'admin_action_etb_export_template_html', 'etb_handle_export_template_html' );
+
+/**
+ * Handles the actual logic for exporting an email template to HTML.
+ *
+ * @since 1.0.0
+ */
+function etb_handle_export_template_html() {
+    // Verify nonce.
+    if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'etb_export_template_html_nonce' ) ) {
+        wp_die( esc_html__( 'Security check failed. Could not export template.', 'email-template-builder' ), 'Nonce Verification Failed', array( 'response' => 403 ) );
+    }
+
+    // Check user capabilities
+    if ( ! current_user_can( 'manage_options' ) ) { // Or a more specific capability
+        wp_die( esc_html__( 'You do not have sufficient permissions to export templates.', 'email-template-builder' ), 'Permission Denied', array( 'response' => 403 ) );
+    }
+
+    $template_id = isset( $_GET['template_id'] ) ? absint( $_GET['template_id'] ) : 0;
+    $lang_to_export = isset( $_GET['lang'] ) ? sanitize_key( $_GET['lang'] ) : 'en'; // Default to English
+
+    if ( ! $template_id ) {
+        wp_die( esc_html__( 'No template ID provided for export.', 'email-template-builder' ), 'Missing ID', array( 'response' => 400 ) );
+    }
+
+    $post = get_post( $template_id );
+    if ( ! $post || $post->post_type !== 'email_template' ) {
+        wp_die( esc_html__( 'Invalid template ID or template not found.', 'email-template-builder' ), 'Invalid ID', array( 'response' => 404 ) );
+    }
+
+    $template_structure_json = get_post_meta( $template_id, '_template_structure', true );
+    $sections = ! empty( $template_structure_json ) ? json_decode( $template_structure_json, true ) : array();
+    if ( json_last_error() !== JSON_ERROR_NONE ) {
+        wp_die( esc_html__( 'Error decoding template structure.', 'email-template-builder' ), 'JSON Error', array( 'response' => 500 ) );
+    }
+
+    // Get all translatable labels (similar to how it's done in admin-page.php for JS)
+    // This should ideally come from a shared source or helper function.
+    $translatable_labels_raw = etb_get_translatable_labels_config(); // Centralized function
+
+    $sections_html = '';
+    foreach ( $sections as $section ) {
+        $sections_html .= etb_render_section_for_export( $section, $lang_to_export, $translatable_labels_raw );
+    }
+
+    // Basic Email Wrapper Styles - these should be inlined for max compatibility
+    $email_body_style = "margin:0; padding:0; background-color:#f0f0f0; font-family: Arial, sans-serif; font-size: 14px; line-height:1.6;";
+    $email_container_style = "max-width:600px; margin:20px auto; background-color:#ffffff; border:1px solid #dddddd; padding:20px;";
+    // More specific styles will be inlined per section by etb_render_section_for_export
+
+    $full_html = sprintf(
+        '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="%s">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>%s</title>
+    <!-- It is generally recommended to inline all CSS for email -->
+    <style type="text/css">
+        body { %s }
+        .email-container { %s }
+        /* Other global styles that might not be fully inlined by all tools, but primarily rely on inline */
+        img { display: block; max-width: 100%%; height: auto; }
+    </style>
+</head>
+<body style="%s">
+    <table width="100%%" border="0" cellpadding="0" cellspacing="0" bgcolor="#f0f0f0">
+        <tr>
+            <td align="center" valign="top">
+                <table class="email-container" width="600" border="0" cellpadding="0" cellspacing="0" style="%s">
+                    <tr>
+                        <td>
+                            %s
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>',
+        esc_attr( $lang_to_export ),
+        esc_html( $post->post_title . " (" . strtoupper($lang_to_export) . ")" ),
+        $email_body_style, // For <style> block
+        $email_container_style, // For <style> block
+        $email_body_style, // For <body> inline style
+        $email_container_style, // For .email-container table inline style
+        $sections_html // Content is already processed by etb_render_section_for_export
+    );
+
+    $filename = sanitize_file_name( $post->post_title . '_' . $lang_to_export . '.html' );
+    header( 'Content-Type: text/html; charset=utf-8' );
+    header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+    echo $full_html; //
+    exit;
+}
+
+?>

--- a/builder/helpers.php
+++ b/builder/helpers.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Helper functions for the Email Template Builder.
+ *
+ * @package EmailTemplateBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Retrieves the configuration for translatable labels.
+ * This function serves as a central point for defining or fetching the
+ * dictionary of predefined translatable labels used throughout the builder.
+ *
+ * @since 1.0.0
+ * @return array The array of translatable labels, structured as [key => [lang_code => translation]].
+ */
+function etb_get_translatable_labels_config() {
+    // This could be expanded to load from a filter, theme option, or a dedicated config file.
+    // Example: return apply_filters('etb_translatable_labels', $default_labels);
+	return array(
+        'greeting_team' => array( 'en' => 'Hi Team', 'pt' => 'Olá equipe', 'es' => 'Hola equipo'),
+        'thank_you'     => array( 'en' => 'Thank you', 'pt' => 'Obrigado', 'es' => 'Gracias'),
+        'signature'     => array( 'en' => 'Best regards', 'pt' => 'Atenciosamente', 'es' => 'Saludos cordiales'),
+        // Add more predefined snippets here
+    );
+}
+
+/**
+ * Renders a single section into email-compatible HTML for export.
+ *
+ * This function takes a section object (as stored in the post meta) and generates
+ * the corresponding HTML markup suitable for email clients. It handles different
+ * section types, processes translatable snippets, and ensures basic email styling
+ * (table-based layout, inline styles where appropriate).
+ *
+ * @since 1.0.0
+ * @param array  $section             The section data array. Expected keys: 'type', 'content'.
+ *                                    'content' structure varies by type.
+ * @param string $lang                The language code (e.g., 'en', 'pt', 'es') for which to render the content.
+ * @param array  $translatable_labels The full array of translatable labels, passed from etb_get_translatable_labels_config().
+ * @return string                     The generated HTML string for the section.
+ */
+function etb_render_section_for_export( $section, $lang, $translatable_labels ) {
+    $html_output  = '';
+    $section_type = isset( $section['type'] ) ? $section['type'] : 'text'; // Default to text if type is missing
+    $content_data = isset( $section['content'] ) ? $section['content'] : array();
+
+    /**
+	 * Helper function to get localized content for a specific field within a section's content.
+	 *
+	 * @param array|string $field_content The content part for a specific field (e.g., $content_data['url'] or $content_data itself for text).
+	 * @param string       $current_lang  The target language.
+	 * @param string       $default_lang  The fallback language (usually 'en').
+	 * @return string The localized string or an empty string.
+	 */
+    $get_localized_value = function( $field_content, $current_lang, $default_lang = 'en' ) {
+        if ( is_array( $field_content ) ) {
+            return isset( $field_content[$current_lang] ) && !empty($field_content[$current_lang])
+                   ? $field_content[$current_lang]
+                   : (isset( $field_content[$default_lang] ) ? $field_content[$default_lang] : '');
+        }
+        return strval( $field_content ); // If it's already a simple string (e.g. older text content structure)
+    };
+
+    // Process snippets for text-based content fields (applies to text, button text, image alt)
+    $process_text_for_snippets_and_vars = function( $text_input ) use ( $translatable_labels, $lang ) {
+        if ( !is_string($text_input) ) {
+            return '';
+        }
+        // Process snippets
+        $processed_text = preg_replace_callback(
+            '/\{\{snippet:([a-zA-Z0-9_]+)\}\}/',
+            function( $matches ) use ( $translatable_labels, $lang ) {
+                $snippet_key = $matches[1];
+                if ( isset( $translatable_labels[$snippet_key] ) && isset( $translatable_labels[$snippet_key][$lang] ) ) {
+                    return $translatable_labels[$snippet_key][$lang];
+                }
+                return $matches[0]; // Return original placeholder if not found
+            },
+            $text_input
+        );
+        // Note: Dynamic variables {{variable}} are intentionally left as is (not processed by this function).
+        // They will be part of the $processed_text.
+        return $processed_text;
+    };
+
+
+    // --- Outer Table for Spacing (common email practice) ---
+    // This provides consistent spacing around each content block.
+    $html_output .= '<table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-bottom: 10px;">'; // Added margin-bottom for spacing
+    $html_output .= '<tr><td>'; // Removed default padding, will be handled by inner content tables
+
+    switch ( $section_type ) {
+        case 'text':
+            $text_content = $get_localized_value( $content_data, $lang ); // For text, content_data is the multilingual text object
+            $processed_content = $process_text_for_snippets_and_vars( $text_content );
+            $text_style = 'font-family: Arial, Helvetica, sans-serif; font-size: 14px; line-height: 1.6; color: #333333; padding:10px;';
+            $html_output .= sprintf(
+                '<table width="100%%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td style="%s">%s</td></tr></table>',
+                esc_attr( $text_style ),
+                nl2br( esc_html( $processed_content ) ) // Content is already processed for snippets, now escape and nl2br
+            );
+            break;
+
+        case 'image':
+            $image_url = $get_localized_value( isset($content_data['url']) ? $content_data['url'] : '', $lang );
+            $alt_text  = $process_text_for_snippets_and_vars( $get_localized_value( isset($content_data['alt']) ? $content_data['alt'] : '', $lang ) );
+
+            if ( !empty($image_url) ) {
+                 $html_output .= sprintf(
+                    '<table width="100%%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td align="center" style="padding: 10px;"><img src="%s" alt="%s" style="display:block; max-width:100%%; height:auto; border:0;" /></td></tr></table>',
+                    esc_url( $image_url ), // URL should be clean
+                    esc_attr( $alt_text )  // Alt text is processed for snippets then escaped
+                );
+            }
+            break;
+
+        case 'button':
+            $button_text     = $text_content; // Already processed for snippets
+            $button_url      = isset($content_data['url'][$lang]) ? $content_data['url'][$lang] : (isset($content_data['url']['en']) ? $content_data['url']['en'] : '#');
+            $button_bg_color = isset($content_data['bgColor']) ? sanitize_hex_color($content_data['bgColor']) : '#007bff'; // Default color
+
+            // Basic button styling - more can be added
+            // VML for Outlook is often needed for rounded corners etc., but keeping it simpler for now.
+            $button_table_style = 'text-align: center;'; // Centers the button table
+            $button_td_style    = sprintf(
+                'background-color:%s; border-radius:5px; padding:12px 25px;', // Padding for button size
+                esc_attr($button_bg_color)
+            );
+            $button_link_style  = 'font-family: Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; display:inline-block;';
+
+            if (!empty($button_text)) {
+                $html_output .= sprintf(
+                    '<table width="100%%" border="0" cellspacing="0" cellpadding="0" role="presentation" style="%s"><tr><td align="center"><table border="0" cellspacing="0" cellpadding="0" role="presentation"><tr><td align="center" style="%s"><a href="%s" target="_blank" style="%s">%s</a></td></tr></table></td></tr></table>',
+                    esc_attr($button_table_style),
+                    esc_attr($button_td_style),
+                    esc_url($button_url),
+                    esc_attr($button_link_style),
+                    esc_html($button_text)
+                );
+            }
+            break;
+
+        case 'divider':
+            $divider_style = 'border-top:1px solid #dddddd; height:1px; line-height:1px; font-size:0px; margin:15px 0;';
+            $html_output .= sprintf(
+                '<table width="100%%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td style="padding:10px 0;"><div style="%s">&nbsp;</div></td></tr></table>',
+                esc_attr($divider_style)
+            );
+            break;
+
+        default:
+            $html_output .= sprintf(
+                '<table width="100%%" border="0" cellpadding="0" cellspacing="0" role="presentation"><tr><td style="padding:10px; color:red; text-align:center;">Unsupported section type: %s</td></tr></table>',
+                esc_html( $section['type'] )
+            );
+            break;
+    }
+
+    $html_output .= '</td></tr></table>'; // End of outer spacing table cell and table
+    return $html_output;
+}
+
+?>

--- a/builder/post-type.php
+++ b/builder/post-type.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Registers the Custom Post Type for Email Templates.
+ *
+ * @package EmailTemplateBuilder
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Registers the 'email_template' Custom Post Type.
+ *
+ * This CPT is used to store the email templates created with the builder.
+ * It supports a title and custom meta fields for storing the template structure.
+ *
+ * @since 1.0.0
+ */
+function etb_register_template_post_type() {
+	/**
+	 * Labels for the Custom Post Type.
+	 *
+	 * @var array
+	 */
+	$labels = array(
+		'name'               => _x( 'Email Templates', 'post type general name', 'email-template-builder' ),
+		'singular_name'      => _x( 'Email Template', 'post type singular name', 'email-template-builder' ),
+		'menu_name'          => _x( 'Email Templates', 'admin menu', 'email-template-builder' ),
+		'name_admin_bar'     => _x( 'Email Template', 'add new on admin bar', 'email-template-builder' ),
+		'add_new'            => _x( 'Add New', 'email template', 'email-template-builder' ),
+		'add_new_item'       => __( 'Add New Email Template', 'email-template-builder' ),
+		'new_item'           => __( 'New Email Template', 'email-template-builder' ),
+		'edit_item'          => __( 'Edit Email Template', 'email-template-builder' ),
+		'view_item'          => __( 'View Email Template', 'email-template-builder' ),
+		'all_items'          => __( 'All Email Templates', 'email-template-builder' ),
+		'search_items'       => __( 'Search Email Templates', 'email-template-builder' ),
+		'parent_item_colon'  => __( 'Parent Email Templates:', 'email-template-builder' ),
+		'not_found'          => __( 'No email templates found.', 'email-template-builder' ),
+		'not_found_in_trash' => __( 'No email templates found in Trash.', 'email-template-builder' ),
+	);
+
+	$args = array(
+		'labels'             => $labels,
+		'public'             => false, // Not public on the front-end, only admin accessible.
+		'publicly_queryable' => false,
+		'show_ui'            => true, // Show in admin.
+		'show_in_menu'       => false, // Will be added under a custom top-level menu page.
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'email-templates' ),
+		'capability_type'    => 'post',
+		'has_archive'        => false,
+		'hierarchical'       => false,
+		'menu_position'      => 20, // Below Pages.
+		'menu_icon'          => 'dashicons-email-alt', // WordPress Dashicon.
+		'supports'           => array( 'title' ), // We'll use post meta for content.
+		'show_in_rest'       => true, // Enable REST API support.
+		'public'             => false, // Not public on the front-end.
+		'publicly_queryable' => false, // Not queryable on the front-end.
+		'show_ui'            => true, // Show in admin UI.
+		'show_in_menu'       => false, // Will be under our custom top-level menu.
+	);
+
+	register_post_type( 'email_template', $args );
+
+	/**
+	 * Register meta field for storing the template structure.
+	 * This allows the '_template_structure' meta to be accessed via the REST API.
+	 *
+	 * @see register_post_meta()
+	 */
+	register_post_meta(
+		'email_template',
+		'_template_structure',
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string', // JSON stored as a string.
+			'auth_callback' => function () {
+				// Ensure only users who can edit posts (of this CPT) can update this meta.
+				// Adjust capability check if more specific capabilities are defined for the CPT.
+				return current_user_can( 'edit_posts' ); // General check, CPT specific would be better if defined
+			},
+		)
+	);
+
+	// Example of registering other meta fields if needed in the future:
+	/*
+	register_post_meta( 'email_template', '_template_content_en', array(
+		'show_in_rest' => true,
+		'single' => true,
+		'type' => 'string',
+		'auth_callback' => function() { return current_user_can('edit_posts'); }
+	) );
+	register_post_meta( 'email_template', '_template_content_pt', array(
+		'show_in_rest' => true,
+		'single' => true,
+		'type' => 'string',
+		'auth_callback' => function() { return current_user_can('edit_posts'); }
+	) );
+	register_post_meta( 'email_template', '_template_content_es', array(
+		'show_in_rest' => true,
+		'single' => true,
+		'type' => 'string',
+		'auth_callback' => function() { return current_user_can('edit_posts'); }
+	) );
+	*/
+}
+add_action( 'init', 'etb_register_template_post_type' );
+
+?>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Theme functions and definitions.
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Email Template Builder: Include CPT registration.
+ *
+ * This line includes the custom post type definition for the email templates.
+ * It's placed at the top to ensure the CPT is registered early.
+ */
+require_once get_template_directory() . '/builder/post-type.php';
+
+/**
+ * Email Template Builder: Include Admin Page and UI.
+ *
+ * This line includes the admin page registration for the email template builder.
+ */
+require_once get_template_directory() . '/builder/admin-page.php';
+
+/**
+ * Email Template Builder: Include Export Functionality.
+ *
+ * Handles HTML export of templates.
+ */
+require_once get_template_directory() . '/builder/export.php';
+
+/**
+ * Email Template Builder: Include Helper Functions.
+ *
+ * Contains utility functions for the builder.
+ */
+require_once get_template_directory() . '/builder/helpers.php';
+
+
+// Add other theme setup functions and includes below this line.
+
+/**
+ * Example: Enqueue theme stylesheet.
+ */
+// function theme_enqueue_styles() {
+// wp_enqueue_style( 'mytheme-style', get_stylesheet_uri() );
+// }
+// add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
+
+?>


### PR DESCRIPTION
- Added Custom Post Type 'email_template' for data storage.
- Implemented admin page with Alpine.js for the builder UI.
- Features include:
  - Section-based editing (Text, Image, Button, Divider) with multilingual support.
  - Drag-and-drop reordering of sections.
  - Live preview in an iframe, updating with changes.
  - CRUD operations (List, Create, Edit, Delete, Clone) via REST API.
  - Export template to HTML (current language).
  - Reset to last saved state.
  - Dynamic variable and translatable snippet insertion.
  - Basic multi-user awareness (displays last editor).
- Code modularized into PHP files for CPT, admin page, list table, helpers, export.
- CSS moved to a separate stylesheet.
- Added PHPDoc comments to PHP files and JSDoc-style comments to the main JS file.