### PR TITLE
Implement Email Template Builder as a theme component

### DIFF
--- a/email-builder/assets/css/email-builder.css
+++ b/email-builder/assets/css/email-builder.css
@@ -1,0 +1,231 @@
+/* Email Template Builder - Main Styles */
+body.page-template-page-template-email-builder {
+    /* Potentially override theme body styles for a fuller app experience if needed */
+    /* margin: 0; padding: 0; */
+}
+
+.etb-app-theme-container { /* This class is on the main div in the page template */
+    display: flex;
+    flex-direction: column; /* Stack app and action bar vertically */
+    height: calc(100vh - 100px); /* Adjust 100px based on theme header/admin bar height */
+    min-height: 600px; /* Minimum height for usability */
+    border: 1px solid #ccd0d4;
+    background-color: #f6f7f7;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+    margin: 20px; /* Adjust if theme adds too much padding/margin around page content */
+}
+
+#etb-app-container { /* Inner container for sidebar and preview */
+    display: flex;
+    flex-grow: 1; /* Takes up available space from parent */
+    overflow: hidden; /* Prevent app from causing page scrollbars if possible */
+}
+
+#etb-sidebar-panel {
+    width: 320px;
+    min-width: 280px; /* Prevent from becoming too small */
+    background-color: #ffffff;
+    border-right: 1px solid #ccd0d4;
+    padding: 0; /* Padding will be on inner sections */
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto; /* Scroll sidebar content if it overflows */
+}
+
+.etb-sidebar-header {
+    padding: 15px;
+    border-bottom: 1px solid #ccd0d4;
+    background-color: #f0f0f1;
+}
+.etb-sidebar-header h2 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+#etb-template-management-section,
+#etb-current-template-name-section,
+#etb-controls-section {
+    padding: 15px;
+    border-bottom: 1px solid #e5e5e5;
+}
+#etb-template-management-section h3,
+#etb-controls-section h4 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 14px;
+}
+#etb-template-management-section label,
+#etb-current-template-name-section label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+#etb-template-management-section select,
+#etb-current-template-name-section input[type="text"] {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+}
+.etb-template-buttons button {
+    margin-right: 5px;
+    margin-bottom: 5px;
+}
+.button.button-danger { /* Custom class for delete button */
+    background-color: #d63638;
+    border-color: #d63638;
+    color: #fff;
+}
+.button.button-danger:hover {
+    background-color: #b02a2c;
+    border-color: #b02a2c;
+}
+
+
+#etb-controls-section {
+    flex-grow: 1; /* Allow this section to take remaining space in sidebar */
+    overflow-y: auto; /* If many controls, make this part scrollable */
+}
+.etb-no-controls-message {
+    color: #555;
+    font-style: italic;
+}
+
+
+#etb-main-preview-area {
+    flex-grow: 1;
+    display: flex; /* Use flex for the tabs component */
+    flex-direction: column; /* Stack tab nav and content */
+    padding: 15px;
+    background-color: #f6f7f7; /* Light background for the preview area */
+}
+
+#etb-preview-tabs {
+    flex-grow: 1; /* Tabs component takes available space */
+    display: flex;
+    flex-direction: column;
+}
+
+/* jQuery UI Tabs Styling */
+#etb-preview-tabs .ui-tabs-nav {
+    padding: 0;
+    margin: 0 0 0px 0; /* Remove bottom margin to connect with panel border */
+    border: none; /* Remove default jQuery UI nav border */
+    background: none; /* Remove default jQuery UI nav background */
+    border-bottom: 1px solid #ccc; /* Add a bottom border to the nav */
+}
+#etb-preview-tabs .ui-tabs-nav li {
+    display: inline-block;
+    list-style: none;
+    margin: 0 2px -1px 0; /* Negative margin to overlap border */
+    padding: 0;
+    border: 1px solid #ccc;
+    border-bottom: none; /* Remove bottom border from li */
+    border-radius: 4px 4px 0 0;
+    background-color: #e0e0e0;
+    position: relative; /* For z-index if needed */
+}
+#etb-preview-tabs .ui-tabs-nav li a {
+    display: block;
+    padding: 10px 15px;
+    text-decoration: none;
+    color: #333;
+    font-weight: bold;
+    outline: none;
+}
+#etb-preview-tabs .ui-tabs-nav li.ui-tabs-active {
+    background-color: #fff; /* Active tab matches panel background */
+    border-bottom: 1px solid #fff; /* Hide bottom border by matching color */
+}
+#etb-preview-tabs .ui-tabs-nav li.ui-tabs-active a {
+    color: #0073aa; /* WordPress blue for active tab text */
+}
+
+#etb-preview-tabs .etb-preview-tab-content.ui-tabs-panel {
+    padding: 0; /* Remove padding as iframe takes full space */
+    border: 1px solid #ccc;
+    border-top: none; /* Top border is visually handled by active tab */
+    background-color: #fff;
+    flex-grow: 1; /* Panel takes available vertical space */
+    overflow: hidden; /* Iframe will handle its own scroll */
+    position: relative; /* For iframe absolute positioning if needed */
+}
+
+#etb-preview-tabs iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: block; /* Remove any extra space below iframe */
+}
+
+#etb-action-bar {
+    padding: 15px;
+    border-top: 1px solid #ccd0d4;
+    text-align: right;
+    background-color: #ffffff;
+    flex-shrink: 0; /* Prevent action bar from shrinking */
+}
+#etb-action-bar button {
+    margin-left: 10px;
+}
+#etb-action-bar button:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+
+/* Sortable items styling (placeholders for now) */
+#etb-sortable-items-container .etb-sortable-section {
+    border: 1px solid #e0e0e0;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: #fdfdfd;
+    cursor: move;
+    border-radius: 3px;
+}
+#etb-sortable-items-container .etb-sortable-section h5 {
+    margin: 0 0 8px 0;
+    font-size: 13px;
+    cursor: grab;
+}
+#etb-sortable-items-container .etb-sortable-section .etb-control-group label {
+    display: block;
+    margin-bottom: 3px;
+    font-size: 12px;
+}
+#etb-sortable-items-container .etb-sortable-section .etb-control-group input[type="text"],
+#etb-sortable-items-container .etb-sortable-section .etb-control-group textarea {
+    width: 100%;
+    padding: 6px;
+    margin-bottom: 8px;
+    box-sizing: border-box;
+    font-size: 13px;
+}
+#etb-sortable-items-container .etb-sortable-section .etb-control-group textarea {
+    min-height: 60px;
+    resize: vertical;
+}
+
+
+.etb-sortable-placeholder {
+    border: 2px dashed #0073aa;
+    background-color: #f0f8ff;
+    height: 50px;
+    margin-bottom: 10px;
+    border-radius: 3px;
+}
+
+/* Utility for screen reader text */
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+}

--- a/email-builder/assets/js/email-builder.js
+++ b/email-builder/assets/js/email-builder.js
@@ -1,0 +1,761 @@
+// Email Template Builder - Main JavaScript File
+(function($) {
+    'use strict';
+
+    let currentTemplateId = null; // Stores the ID of the template being edited
+    let isDirty = false; // Flag to track unsaved changes
+
+    // Store the initial HTML template provided by the user.
+    // This will be populated by wp_localize_script.
+    let baseTemplateHtml = '';
+    let currentPreviews = { en: '', pt: '', es: '' }; // Store current HTML state for each language
+    let translations = {}; // Placeholder for the translation dictionary
+
+    // --- Utility Functions ---
+    function setDirty(dirty) {
+        isDirty = dirty;
+        $('#etb-save-template-button').prop('disabled', !dirty);
+        $('#etb-reset-template-button').prop('disabled', !dirty);
+    }
+
+    function updatePreview(lang, htmlContent) {
+        const iframe = $(`#etb-iframe-${lang}`)[0];
+        if (iframe) {
+            const doc = iframe.contentWindow.document;
+            doc.open();
+            doc.write(htmlContent);
+            doc.close();
+            currentPreviews[lang] = htmlContent; // Store the updated HTML
+            // console.log(`Preview updated for ${lang}`);
+        } else {
+            console.error(`Iframe for language ${lang} not found.`);
+        }
+    }
+
+    // Simplified translation function
+    function translate(text, targetLang, sectionId = null) {
+        // Try section-specific key first if provided (e.g., for disambiguation)
+        if (sectionId && translations[sectionId] && translations[sectionId][text] && translations[sectionId][text][targetLang.toUpperCase()]) {
+            return translations[sectionId][text][targetLang.toUpperCase()];
+        }
+        // Try general text key
+        if (translations[text] && translations[text][targetLang.toUpperCase()]) {
+            return translations[text][targetLang.toUpperCase()];
+        }
+        // Fallback for dynamic variables: do not translate
+        if (text.match(/\{\{[^{}]+\}\}/g)) { // Check for {{variable}}
+            return text;
+        }
+        // Fallback: if no translation, return original text for EN, or marked text for others
+        if (targetLang.toLowerCase() === 'en') {
+            return text;
+        }
+        // console.warn(`No translation for "${text}" to ${targetLang.toUpperCase()}`);
+        return `[${targetLang.toUpperCase()}] ${text}`;
+    }
+
+    // Helper to get content from a section in an HTML string
+    function extractSectionContent(htmlString, sectionId, sectionType, lang = 'en') {
+        if (!htmlString) {
+            return sectionType === 'image' ? { src: '', alt: '' } : '';
+        }
+        let tempDom = $('<div>').html(htmlString);
+        let sectionEl = tempDom.find(`[data-etb-section-id="${sectionId}"]`);
+
+        if (!sectionEl.length) {
+            return sectionType === 'image' ? { src: '', alt: '' } : '';
+        }
+
+        if (sectionType === 'image') {
+            let img = sectionEl.find('img');
+            return {
+                src: img.attr('src') || '',
+                alt: img.attr('alt') || ''
+                // For multilingual images, if src can change per lang, this needs adjustment
+            };
+        } else { // text, textarea
+            return sectionEl.text().trim();
+        }
+    }
+
+
+    // --- Core Template Handling ---
+    function loadBaseStructure(htmlForParsing, initialValues = null) {
+        if (!htmlForParsing || htmlForParsing.length === 0) {
+            console.warn("Initial template HTML not provided or empty for parsing.");
+            baseTemplateHtml = '<!DOCTYPE html><html><head><title>Email</title><style>body{font-family:Arial,sans-serif;}</style></head><body><div data-etb-section-id="greeting" data-etb-type="text"><p>Hello {{name}}!</p></div><div data-etb-section-id="body" data-etb-type="textarea"><p>This is the default body content.</p></div></body></html>';
+            currentPreviews.en = baseTemplateHtml;
+        } else {
+            baseTemplateHtml = htmlForParsing; // Keep the original structure for reference
+            currentPreviews.en = htmlForParsing; // EN preview starts with the base
+        }
+
+        // Generate other language previews from EN version (initial load)
+        // This is a very naive initial translation - proper translation will be more complex
+        currentPreviews.pt = applyTranslationsToHtml(currentPreviews.en, 'pt');
+        currentPreviews.es = applyTranslationsToHtml(currentPreviews.en, 'es');
+
+        updatePreview('en', currentPreviews.en);
+        updatePreview('pt', currentPreviews.pt);
+        updatePreview('es', currentPreviews.es);
+
+        parseTemplateForControls(currentPreviews.en, initialValues); // Parse EN version to build controls
+        setDirty(false);
+    }
+
+    // Function to apply translations to an HTML string
+    // This is a simplified version. Real-world scenario might involve more robust parsing.
+    function applyTranslationsToHtml(htmlString, targetLang) {
+        let translatedHtml = htmlString;
+        // Example: find elements with data-translatable attribute or specific text nodes
+        // This needs to be more sophisticated based on how translatable parts are marked in your HTML.
+        // For now, let's assume we find text nodes and try to translate them.
+        // This is highly conceptual and would need a proper DOM parser on the string if complex.
+
+        // A more realistic approach: iterate over known translatable keys from controls
+        $('#etb-sortable-items-container .etb-translatable-control').each(function() {
+            const control = $(this);
+            const originalText = control.data('original-en-text'); // Assume this is stored
+            const sectionId = control.closest('.etb-sortable-section').data('etb-section-id');
+            const targetSelector = `[data-etb-section-id="${sectionId}"]`; // Simplified selector
+
+            if (originalText) {
+                const translatedText = translate(originalText, targetLang);
+                // This is tricky: how to replace only the correct text in the HTML string?
+                // Using a regex might be too fragile. For now, this is a placeholder.
+                // A better way is to update a DOM representation and then serialize it.
+                // Or, each control update directly modifies language-specific DOMs in iframes.
+            }
+        });
+        // For now, let's just return the htmlString and handle translation on control change
+        return htmlString;
+    }
+
+    function parseTemplateForControls(htmlContent, initialValues) {
+        console.log("Parsing template for controls...");
+        const controlsContainer = $('#etb-sortable-items-container');
+        controlsContainer.empty(); // Clear existing controls
+
+        // Define editable sections based on data attributes in the HTML
+        // Example: <div data-etb-section-id="greeting" data-etb-type="text" data-etb-label="Greeting Message">...</div>
+        //          <div data-etb-section-id="main_image" data-etb-type="image" data-etb-label="Main Image"><img></div>
+
+        let tempDom = $('<div>').html(htmlContent); // Create a temporary DOM to parse
+
+        tempDom.find('[data-etb-section-id]').each(function(index) {
+            const section = $(this);
+            const sectionId = section.data('etb-section-id');
+            const sectionType = section.data('etb-type') || 'text'; // Default to text
+            const sectionLabel = section.data('etb-label') || sectionId.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+            const isTranslatable = section.data('etb-translatable') !== 'false'; // Translatable by default unless explicitly false
+
+            let controlHtml = `<div class="etb-sortable-section" data-etb-section-id="${sectionId}" data-etb-section-type="${sectionType}" data-etb-translatable="${isTranslatable}"><h5>${sectionLabel}</h5>`;
+
+            const enValue = extractSectionContent(htmlContent, sectionId, sectionType, 'en');
+            let ptValue = '', esValue = '';
+
+            if (isTranslatable) {
+                if (initialValues && initialValues[sectionId]) { // If loading a saved template
+                    ptValue = initialValues[sectionId].pt || translate(enValue, 'pt', sectionId);
+                    esValue = initialValues[sectionId].es || translate(enValue, 'es', sectionId);
+                } else { // New template or no specific saved values for PT/ES
+                    ptValue = translate(enValue, 'pt', sectionId);
+                    esValue = translate(enValue, 'es', sectionId);
+                }
+            }
+
+
+            if (sectionType === 'text' || sectionType === 'textarea') {
+                const inputTag = sectionType === 'textarea' ? 'textarea' : 'input type="text"';
+                const enInput = `<${inputTag} id="ctrl_${sectionId}_en" class="etb-content-control etb-lang-en" data-lang="en">${sectionType === 'textarea' ? enValue : ''}</${inputTag}>`;
+                if(sectionType === 'text') $(document).ready(() => $(`#ctrl_${sectionId}_en`).val(enValue));
+
+
+                controlHtml += `<div class="etb-control-group">
+                                <label for="ctrl_${sectionId}_en">EN:</label>
+                                ${enInput}
+                            </div>`;
+                if (isTranslatable) {
+                    const ptInput = `<${inputTag} id="ctrl_${sectionId}_pt" class="etb-content-control etb-lang-pt" data-lang="pt">${sectionType === 'textarea' ? ptValue : ''}</${inputTag}>`;
+                    if(sectionType === 'text') $(document).ready(() => $(`#ctrl_${sectionId}_pt`).val(ptValue));
+
+                    const esInput = `<${inputTag} id="ctrl_${sectionId}_es" class="etb-content-control etb-lang-es" data-lang="es">${sectionType === 'textarea' ? esValue : ''}</${inputTag}>`;
+                    if(sectionType === 'text') $(document).ready(() => $(`#ctrl_${sectionId}_es`).val(esValue));
+
+                    controlHtml += `<div class="etb-control-group">
+                                    <label for="ctrl_${sectionId}_pt">PT:</label>
+                                    ${ptInput}
+                                </div>
+                                <div class="etb-control-group">
+                                    <label for="ctrl_${sectionId}_es">ES:</label>
+                                    ${esInput}
+                                </div>`;
+                }
+            } else if (sectionType === 'image') {
+                const enImgDetails = extractSectionContent(htmlContent, sectionId, sectionType, 'en'); // Expects {src: '', alt:''}
+                let ptAlt = '', esAlt = '';
+
+                if (isTranslatable) {
+                     if (initialValues && initialValues[sectionId] && initialValues[sectionId].alt_pt) {
+                        ptAlt = initialValues[sectionId].alt_pt;
+                    } else {
+                        ptAlt = translate(enImgDetails.alt, 'pt', sectionId + '_alt');
+                    }
+                    if (initialValues && initialValues[sectionId] && initialValues[sectionId].alt_es) {
+                        esAlt = initialValues[sectionId].alt_es;
+                    } else {
+                        esAlt = translate(enImgDetails.alt, 'es', sectionId + '_alt');
+                    }
+                }
+
+                controlHtml += `<div class="etb-control-group">
+                                <label for="ctrl_${sectionId}_src">Image URL:</label>
+                                <input type="text" id="ctrl_${sectionId}_src" class="etb-image-control etb-image-src" value="${enImgDetails.src}" data-target-attr="src" />
+                                <label for="ctrl_${sectionId}_alt_en">Alt Text (EN):</label>
+                                <input type="text" id="ctrl_${sectionId}_alt_en" class="etb-image-control etb-image-alt etb-lang-en" value="${enImgDetails.alt}" data-target-attr="alt" data-lang="en" />
+                            </div>`;
+                 if (isTranslatable) {
+                    controlHtml += `<div class="etb-control-group">
+                                <label for="ctrl_${sectionId}_alt_pt">Alt Text (PT):</label>
+                                <input type="text" id="ctrl_${sectionId}_alt_pt" class="etb-image-control etb-image-alt etb-lang-pt" value="${ptAlt}" data-target-attr="alt" data-lang="pt" />
+                            </div>
+                            <div class="etb-control-group">
+                                <label for="ctrl_${sectionId}_alt_es">Alt Text (ES):</label>
+                                <input type="text" id="ctrl_${sectionId}_alt_es" class="etb-image-control etb-image-alt etb-lang-es" value="${esAlt}" data-target-attr="alt" data-lang="es" />
+                            </div>`;
+                 }
+            }
+            // Add more control types (checkbox, toggle) as needed
+
+            controlHtml += `</div>`; // Close etb-sortable-section
+            controlsContainer.append(controlHtml);
+        });
+
+        if (controlsContainer.children().length === 0) {
+            controlsContainer.html('<p class="etb-no-controls-message">No editable sections (with data-etb-section-id) found in the template.</p>');
+        }
+
+        initializeSortable();
+    }
+
+    function initializeSortable() {
+        const controlsContainer = $('#etb-sortable-items-container');
+        if (controlsContainer.data('ui-sortable')) { // Destroy if already initialized
+            controlsContainer.sortable("destroy");
+        }
+        controlsContainer.sortable({
+            placeholder: "etb-sortable-placeholder",
+            axis: "y",
+            handle: "h5",
+            update: function(event, ui) {
+                setDirty(true);
+                regenerateAllPreviewsFromControls(); // Update preview based on new order
+                console.log("Section order updated.");
+            }
+        }).disableSelection();
+    }
+
+    function getSectionDataFromControls(sectionId, lang) {
+        const sectionDiv = $(`.etb-sortable-section[data-etb-section-id="${sectionId}"]`);
+        const type = sectionDiv.data('etb-section-type');
+        let data = {};
+
+        if (type === 'text' || type === 'textarea') {
+            data.text = $(`#ctrl_${sectionId}_${lang}`).val();
+        } else if (type === 'image') {
+            // For images, EN holds the src, other languages might have different alt texts
+            data.src = $(`#ctrl_${sectionId}_src`).val(); // Assuming src is not translated per se
+            data.alt = $(`#ctrl_${sectionId}_alt_${lang}`).val();
+            if (lang !== 'en' && !data.alt) { // Fallback to EN alt if translated is empty
+                data.alt = $(`#ctrl_${sectionId}_alt_en`).val();
+            }
+        }
+        return data;
+    }
+
+    // Regenerate a single language preview based on current controls and their order
+    function regenerateLangPreview(lang) {
+        let newHtml = baseTemplateHtml; // Start with the base structure
+        let tempDom = $('<div>').html(newHtml); // Create a mutable DOM copy
+
+        // Iterate over sections in the sidebar order
+        $('#etb-sortable-items-container .etb-sortable-section').each(function() {
+            const sectionId = $(this).data('etb-section-id');
+            const sectionData = getSectionDataFromControls(sectionId, lang);
+            const targetElementInDom = tempDom.find(`[data-etb-section-id="${sectionId}"]`);
+
+            if (targetElementInDom.length) {
+                const type = $(this).data('etb-section-type');
+                if (type === 'text' || type === 'textarea') {
+                    // This needs to be smarter, e.g., update specific child element if section is a wrapper
+                    targetElementInDom.text(sectionData.text);
+                } else if (type === 'image') {
+                    targetElementInDom.find('img').attr('src', sectionData.src).attr('alt', sectionData.alt);
+                }
+            }
+        });
+        updatePreview(lang, tempDom.html());
+    }
+
+    function regenerateAllPreviewsFromControls() {
+        regenerateLangPreview('en');
+        regenerateLangPreview('pt');
+        regenerateLangPreview('es');
+    }
+
+
+    // --- Event Listeners ---
+    // Delegated event listener for content controls (text, textarea)
+    $(document).on('input change', '.etb-content-control', function() {
+        const $input = $(this);
+        const lang = $input.data('lang');
+        const sectionId = $input.closest('.etb-sortable-section').data('etb-section-id');
+        const isTranslatable = $input.closest('.etb-sortable-section').data('etb-translatable') === true;
+
+        if (lang === 'en' && isTranslatable) {
+            const enText = $input.val();
+            // Update corresponding PT and ES fields if they haven't been manually edited (or if we want to always force re-translate)
+            // To check for manual edit, we could add a data attribute like 'data-manually-edited'
+            const $ptInput = $(`#ctrl_${sectionId}_pt`);
+            const $esInput = $(`#ctrl_${sectionId}_es`);
+
+            if ($ptInput.length && !$ptInput.data('manually-edited')) {
+                $ptInput.val(translate(enText, 'pt', sectionId));
+            }
+            if ($esInput.length && !$esInput.data('manually-edited')) {
+                $esInput.val(translate(enText, 'es', sectionId));
+            }
+            regenerateAllPreviewsFromControls(); // If EN changes, all might need re-translation
+        } else {
+            // If PT or ES field is edited, mark it as manually edited
+            if (lang !== 'en') {
+                $input.data('manually-edited', true);
+            }
+            regenerateLangPreview(lang); // Regenerate only the affected language preview
+        }
+        setDirty(true);
+    });
+
+    // Delegated event listener for image controls
+    $(document).on('input change', '.etb-image-control', function() {
+        const $input = $(this);
+        const lang = $input.data('lang'); // Relevant for alt tags
+        const sectionId = $input.closest('.etb-sortable-section').data('etb-section-id');
+        const isTranslatable = $input.closest('.etb-sortable-section').data('etb-translatable') === true;
+        const isSrcField = $input.hasClass('etb-image-src');
+
+        if (isSrcField) { // Image source changed (usually only one src input for all langs)
+            regenerateAllPreviewsFromControls();
+        } else if (lang === 'en' && isTranslatable) { // EN alt text changed
+            const enAltText = $input.val();
+            const $ptInput = $(`#ctrl_${sectionId}_alt_pt`);
+            const $esInput = $(`#ctrl_${sectionId}_alt_es`);
+
+            if ($ptInput.length && !$ptInput.data('manually-edited')) {
+                $ptInput.val(translate(enAltText, 'pt', sectionId + '_alt'));
+            }
+            if ($esInput.length && !$esInput.data('manually-edited')) {
+                $esInput.val(translate(enAltText, 'es', sectionId + '_alt'));
+            }
+            regenerateAllPreviewsFromControls();
+        } else { // PT or ES alt text changed
+             if (lang !== 'en') {
+                $input.data('manually-edited', true);
+            }
+            regenerateLangPreview(lang);
+        }
+        setDirty(true);
+    });
+
+
+    // --- Helper: Show Status Message ---
+    function showStatusMessage(message, isError = false) {
+        // Simple alert for now, can be replaced with a dedicated message area in UI
+        alert(message);
+        if (isError) console.error(message); else console.log(message);
+    }
+
+    // --- Template List Management ---
+    function loadTemplatesList() {
+        $.ajax({
+            url: etb_ajax_obj.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'etb_load_templates_list',
+                nonce: etb_ajax_obj.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    const select = $('#etb-template-select');
+                    select.empty().append($('<option>', { value: '', text: etb_ajax_obj.text_strings.select_template_to_load || '-- Select a Template --' }));
+                    response.data.forEach(function(template) {
+                        select.append($('<option>', {
+                            value: template.id,
+                            text: template.name
+                        }));
+                    });
+                } else {
+                    showStatusMessage(response.data.message || 'Error loading templates list.', true);
+                }
+            },
+            error: function(xhr) {
+                showStatusMessage('AJAX error loading templates list: ' + xhr.statusText, true);
+            }
+        });
+    }
+
+    // --- Load Template Data ---
+    function loadTemplateData(templateId) {
+        if (!templateId) {
+            showStatusMessage(etb_ajax_obj.text_strings.select_template_to_load || 'Please select a template.', true);
+            return;
+        }
+        $.ajax({
+            url: etb_ajax_obj.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'etb_load_template_data',
+                nonce: etb_ajax_obj.nonce,
+                template_id: templateId
+            },
+            success: function(response) {
+                if (response.success) {
+                    const data = response.data;
+                    currentTemplateId = data.id;
+                    $('#etb-current-template-name').val(data.name).show();
+
+                    // Load EN content to parse for controls and set as base structure for this load
+                    // The other languages content will be used to populate controls if different,
+                    // or regenerated if structure changed.
+                    baseTemplateHtml = data.content_en; // This becomes the reference for current structure
+                    currentPreviews.en = data.content_en;
+                    currentPreviews.pt = data.content_pt;
+                    currentPreviews.es = data.content_es;
+
+                    updatePreview('en', currentPreviews.en);
+                    updatePreview('pt', currentPreviews.pt);
+                    updatePreview('es', currentPreviews.es);
+
+                    parseTemplateForControls(currentPreviews.en); // Parse current EN structure for controls
+
+                    // After parsing, repopulate controls with loaded language data
+                    // This assumes parseTemplateForControls sets up control IDs like ctrl_{sectionId}_{lang}
+                    $('#etb-sortable-items-container .etb-sortable-section').each(function() {
+                        const sectionId = $(this).data('etb-section-id');
+                        const sectionType = $(this).data('etb-section-type');
+
+                        if (sectionType === 'text' || sectionType === 'textarea') {
+                            // Find the EN text from the loaded EN HTML to ensure correct base for translation
+                            let tempDomEn = $('<div>').html(data.content_en);
+                            let enTextForSection = tempDomEn.find(`[data-etb-section-id="${sectionId}"]`).text().trim();
+
+                            $(`#ctrl_${sectionId}_en`).val(enTextForSection);
+                            $(`#ctrl_${sectionId}_pt`).val(extractSectionText(data.content_pt, sectionId) || translate(enTextForSection, 'pt'));
+                            $(`#ctrl_${sectionId}_es`).val(extractSectionText(data.content_es, sectionId) || translate(enTextForSection, 'es'));
+                        } else if (sectionType === 'image') {
+                             let tempDomEn = $('<div>').html(data.content_en);
+                             let imgEn = tempDomEn.find(`[data-etb-section-id="${sectionId}"] img`);
+                             $(`#ctrl_${sectionId}_src`).val(imgEn.attr('src'));
+                             $(`#ctrl_${sectionId}_alt_en`).val(imgEn.attr('alt'));
+
+                             let tempDomPt = $('<div>').html(data.content_pt);
+                             let imgPt = tempDomPt.find(`[data-etb-section-id="${sectionId}"] img`);
+                             $(`#ctrl_${sectionId}_alt_pt`).val(imgPt.attr('alt') || translate(imgEn.attr('alt') || '', 'pt'));
+
+                             let tempDomEs = $('<div>').html(data.content_es);
+                             let imgEs = tempDomEs.find(`[data-etb-section-id="${sectionId}"] img`);
+                             $(`#ctrl_${sectionId}_alt_es`).val(imgEs.attr('alt') || translate(imgEn.attr('alt') || '', 'es'));
+                        }
+                    });
+
+
+                    setDirty(false);
+                    $('#etb-save-template-button').text(etb_ajax_obj.text_strings.save_template || 'Save Template').prop('disabled', true);
+                    $('#etb-clone-template-button, #etb-delete-template-button, #etb-export-html-button, #etb-reset-template-button').prop('disabled', false);
+                    showStatusMessage(etb_ajax_obj.text_strings.template_loaded || 'Template loaded.');
+                } else {
+                    showStatusMessage(response.data.message || 'Error loading template data.', true);
+                }
+            },
+            error: function(xhr) {
+                showStatusMessage('AJAX error loading template data: ' + xhr.statusText, true);
+            }
+        });
+    }
+    // Helper to extract text for a section from a full HTML string
+    function extractSectionText(htmlString, sectionId) {
+        if (!htmlString) return '';
+        let tempDom = $('<div>').html(htmlString);
+        return tempDom.find(`[data-etb-section-id="${sectionId}"]`).text().trim();
+    }
+
+
+    // --- Save Template Data ---
+    function saveTemplateData() {
+        const templateName = $('#etb-current-template-name').val().trim();
+        if (!templateName) {
+            showStatusMessage(etb_ajax_obj.text_strings.enter_template_name || 'Please enter a template name.', true);
+            $('#etb-current-template-name').focus();
+            return;
+        }
+
+        // Regenerate all previews to ensure currentPreviews are up-to-date before saving
+        regenerateAllPreviewsFromControls();
+
+        const sectionsOrder = [];
+        $('#etb-sortable-items-container .etb-sortable-section').each(function() {
+            sectionsOrder.push($(this).data('etb-section-id'));
+        });
+
+        const dataToSave = {
+            action: 'etb_save_template',
+            nonce: etb_ajax_obj.nonce,
+            name: templateName,
+            content_en: currentPreviews.en,
+            content_pt: currentPreviews.pt,
+            content_es: currentPreviews.es,
+            sections_order: JSON.stringify(sectionsOrder),
+            settings: JSON.stringify({}) // Placeholder for future settings
+        };
+
+        if (currentTemplateId) {
+            dataToSave.template_id = currentTemplateId;
+        }
+
+        $.ajax({
+            url: etb_ajax_obj.ajax_url,
+            type: 'POST',
+            data: dataToSave,
+            success: function(response) {
+                if (response.success) {
+                    currentTemplateId = response.data.template_id; // Update ID if new template
+                    $('#etb-current-template-name').val(response.data.name); // Update name in case it was sanitized
+                    setDirty(false);
+                    $('#etb-save-template-button').text(etb_ajax_obj.text_strings.save_template || 'Save Template');
+                    showStatusMessage(response.data.message || etb_ajax_obj.text_strings.template_saved);
+                    loadTemplatesList(); // Refresh dropdown
+                    // Re-select the saved template in dropdown
+                    $('#etb-template-select').val(currentTemplateId);
+                } else {
+                    showStatusMessage(response.data.message || etb_ajax_obj.text_strings.error_saving, true);
+                }
+            },
+            error: function(xhr) {
+                showStatusMessage('AJAX error saving template: ' + xhr.statusText, true);
+            }
+        });
+    }
+
+    // --- Delete Template ---
+    function deleteTemplate() {
+        const templateIdToDelete = $('#etb-template-select').val();
+        if (!templateIdToDelete) {
+            showStatusMessage(etb_ajax_obj.text_strings.select_template_to_delete || 'Please select a template to delete.', true);
+            return;
+        }
+
+        if (!confirm(etb_ajax_obj.text_strings.confirm_delete || 'Are you sure you want to delete this template?')) {
+            return;
+        }
+
+        $.ajax({
+            url: etb_ajax_obj.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'etb_delete_template',
+                nonce: etb_ajax_obj.nonce,
+                template_id: templateIdToDelete
+            },
+            success: function(response) {
+                if (response.success) {
+                    showStatusMessage(response.data.message || etb_ajax_obj.text_strings.template_deleted);
+                    loadTemplatesList(); // Refresh list
+                    // Reset UI if the deleted template was the one being edited
+                    if (currentTemplateId == templateIdToDelete) {
+                        currentTemplateId = null;
+                        $('#etb-current-template-name').val('').hide();
+                        $('#etb-sortable-items-container').empty().html('<p class="etb-no-controls-message">Select or create a template.</p>');
+                        updatePreview('en', ''); updatePreview('pt', ''); updatePreview('es', '');
+                        setDirty(false);
+                        $('#etb-save-template-button, #etb-clone-template-button, #etb-delete-template-button, #etb-export-html-button, #etb-reset-template-button').prop('disabled', true);
+                    }
+                } else {
+                    showStatusMessage(response.data.message || 'Error deleting template.', true);
+                }
+            },
+            error: function(xhr) {
+                showStatusMessage('AJAX error deleting template: ' + xhr.statusText, true);
+            }
+        });
+    }
+
+    // --- Clone Template ---
+    function cloneTemplate() {
+        const templateIdToClone = $('#etb-template-select').val();
+        if (!templateIdToClone) {
+            showStatusMessage(etb_ajax_obj.text_strings.select_template_to_clone || 'Please select a template to clone.', true);
+            return;
+        }
+
+        $.ajax({
+            url: etb_ajax_obj.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'etb_clone_template',
+                nonce: etb_ajax_obj.nonce,
+                template_id: templateIdToClone
+            },
+            success: function(response) {
+                if (response.success) {
+                    showStatusMessage(response.data.message || etb_ajax_obj.text_strings.template_cloned);
+                    loadTemplatesList(); // Refresh list
+                    // Automatically load the new cloned template for editing
+                    const newTemplate = response.data.new_template;
+                    $('#etb-template-select').val(newTemplate.id); // Select it in dropdown
+                    loadTemplateData(newTemplate.id); // Load its data
+                } else {
+                    showStatusMessage(response.data.message || 'Error cloning template.', true);
+                }
+            },
+            error: function(xhr) {
+                showStatusMessage('AJAX error cloning template: ' + xhr.statusText, true);
+            }
+        });
+    }
+
+    // --- Export HTML ---
+    function exportHtml() {
+        if (!currentTemplateId && !isDirty) { // Also check isDirty for new unsaved templates
+            showStatusMessage(etb_ajax_obj.text_strings.no_template_to_export || 'Load or create a template to export.', true);
+            return;
+        }
+
+        // For simplicity, export English version. Could be enhanced with a language choice.
+        // Ensure currentPreviews.en is up-to-date if there are pending changes.
+        regenerateLangPreview('en'); // Ensure EN preview is current based on controls
+        const htmlContent = currentPreviews.en;
+        const templateName = $('#etb-current-template-name').val().trim() || 'email-template';
+        const filename = templateName.replace(/[^a-z0-9]/gi, '_').toLowerCase() + '_en.html';
+
+        const blob = new Blob([htmlContent], { type: 'text/html' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(link.href); // Clean up
+        showStatusMessage(etb_ajax_obj.text_strings.template_exported || 'Template HTML exported.');
+    }
+
+    // --- Reset Changes ---
+    function resetChanges() {
+        if (!isDirty) {
+            showStatusMessage(etb_ajax_obj.text_strings.no_changes_to_reset || 'No unsaved changes to reset.');
+            return;
+        }
+        if (!confirm(etb_ajax_obj.text_strings.confirm_reset_changes || 'Are you sure you want to discard unsaved changes?')) {
+            return;
+        }
+
+        if (currentTemplateId) {
+            // If it's an existing template, reload its saved state
+            loadTemplateData(currentTemplateId);
+        } else {
+            // If it's a new, unsaved template, reset to the initial base structure
+            loadBaseStructure(etb_ajax_obj.initial_template_html);
+            $('#etb-current-template-name').val(''); // Clear name for new template
+        }
+        setDirty(false); // Changes have been discarded or reloaded
+        showStatusMessage(etb_ajax_obj.text_strings.changes_reset || 'Changes have been reset.');
+    }
+
+
+    // --- Document Ready ---
+    $(function() {
+        console.log('Email Template Builder JS Initialized.');
+        console.log('AJAX Object:', etb_ajax_obj);
+
+        translations = etb_ajax_obj.translations || { // Use translations from PHP if provided
+            "Hello {{name}}!": { "PT": "Olá {{name}}!", "ES": "¡Hola {{name}}!" },
+            "This is the default body content.": { "PT": "Este é o conteúdo padrão do corpo.", "ES": "Este es el contenido del cuerpo predeterminado." },
+        };
+
+        if ($('#etb-preview-tabs').length) {
+            $('#etb-preview-tabs').tabs();
+        }
+
+        loadTemplatesList(); // Load templates into dropdown on page load
+
+        // --- Event Handlers for CRUD ---
+        $('#etb-create-new-template-button').on('click', function() {
+            currentTemplateId = null;
+            $('#etb-current-template-name').val('').show().focus();
+            $('#etb-save-template-button').prop('disabled', false).text(etb_ajax_obj.text_strings.save_template || 'Save New Template');
+            $('#etb-template-select').val('');
+
+            loadBaseStructure(etb_ajax_obj.initial_template_html);
+
+            // Button states for new template
+            $('#etb-load-template-button').prop('disabled', true); // No template selected to load
+            $('#etb-clone-template-button').prop('disabled', true);
+            $('#etb-delete-template-button').prop('disabled', true);
+            $('#etb-export-html-button').prop('disabled', true); // Can't export unsaved
+            $('#etb-reset-template-button').prop('disabled', true); // Nothing to reset to
+            $('#etb-save-template-button').prop('disabled', false); // Can save the new template
+
+            console.log("Creating new template from base structure.");
+        });
+
+        $('#etb-load-template-button').on('click', function() {
+            const selectedId = $('#etb-template-select').val();
+            if (selectedId) {
+                loadTemplateData(selectedId);
+            } else {
+                showStatusMessage(etb_ajax_obj.text_strings.select_template_to_load || 'Please select a template to load.', true);
+            }
+        });
+
+        $('#etb-save-template-button').on('click', function() {
+            saveTemplateData();
+        });
+
+        $('#etb-delete-template-button').on('click', function() {
+            deleteTemplate();
+        });
+
+        $('#etb-clone-template-button').on('click', function() {
+            cloneTemplate();
+        });
+
+        $('#etb-export-html-button').on('click', function() {
+            exportHtml();
+        });
+
+        $('#etb-reset-template-button').on('click', function() {
+            resetChanges();
+        });
+
+        // Enable/disable load, clone, delete buttons based on selection
+        $('#etb-template-select').on('change', function() {
+            const selectedId = $(this).val();
+            if (selectedId) {
+                $('#etb-load-template-button').prop('disabled', false);
+                $('#etb-clone-template-button').prop('disabled', false);
+                $('#etb-delete-template-button').prop('disabled', false);
+            } else {
+                $('#etb-load-template-button').prop('disabled', true);
+                $('#etb-clone-template-button').prop('disabled', true);
+                $('#etb-delete-template-button').prop('disabled', true);
+            }
+        });
+
+        // Initial button states
+        // Create is always enabled. Others depend on context.
+        $('#etb-load-template-button, #etb-clone-template-button, #etb-delete-template-button, #etb-save-template-button, #etb-export-html-button, #etb-reset-template-button').prop('disabled', true);
+        $('#etb-create-new-template-button').prop('disabled', false);
+
+
+    }); // End document ready
+
+})(jQuery);

--- a/email-builder/assets/js/temp-utils.js
+++ b/email-builder/assets/js/temp-utils.js
@@ -1,0 +1,41 @@
+// This is a temporary file to hold utility functions that will be merged into email-builder.js
+
+// Helper to get content from a section in an HTML string
+function extractSectionContent(htmlString, sectionId, sectionType, lang = 'en') {
+    if (!htmlString) {
+        return sectionType === 'image' ? { src: '', alt: '' } : '';
+    }
+    let tempDom = $('<div>').html(htmlString);
+    let sectionEl = tempDom.find(`[data-etb-section-id="${sectionId}"]`);
+
+    if (!sectionEl.length) {
+        return sectionType === 'image' ? { src: '', alt: '' } : '';
+    }
+
+    if (sectionType === 'image') {
+        let img = sectionEl.find('img');
+        return {
+            src: img.attr('src') || '',
+            alt: img.attr('alt') || ''
+        };
+    } else { // text, textarea
+        // This needs to be specific to how content is structured within your section.
+        // For example, if it's just the text of the section div itself:
+        return sectionEl.text().trim();
+        // Or if it's a specific child: sectionEl.find('.content-element').text().trim();
+    }
+}
+
+// Placeholder for translate function to avoid errors if not defined in main yet
+function translate(text, targetLang, sectionId = null) {
+    const translations = (typeof window.etb_translations !== 'undefined') ? window.etb_translations : {}; // Access global if set
+    if (sectionId && translations[sectionId] && translations[sectionId][text] && translations[sectionId][text][targetLang.toUpperCase()]) {
+        return translations[sectionId][text][targetLang.toUpperCase()];
+    }
+    if (translations[text] && translations[text][targetLang.toUpperCase()]) {
+        return translations[text][targetLang.toUpperCase()];
+    }
+    if (text.match(/\{\{[^{}]+\}\}/g)) { return text; }
+    if (targetLang.toLowerCase() === 'en') { return text; }
+    return `[${targetLang.toUpperCase()}] ${text}`;
+}

--- a/email-builder/email-builder.php
+++ b/email-builder/email-builder.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Main file for the Email Template Builder feature.
+ * To be included in the theme's functions.php
+ *
+ * Example: require_once( get_template_directory() . '/email-builder/email-builder.php' );
+ */
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Define constants for the email builder feature
+define( 'ETB_THEME_DIR', get_template_directory() . '/email-builder' );
+define( 'ETB_THEME_URL', get_template_directory_uri() . '/email-builder' );
+define( 'ETB_VERSION', '1.0.0' ); // Version for the builder feature
+
+// Include necessary files
+require_once ETB_THEME_DIR . '/includes/db-setup.php';
+// Shortcode approach not taken, page template is used.
+// require_once ETB_THEME_DIR . '/includes/shortcode.php';
+require_once ETB_THEME_DIR . '/includes/ajax-handlers.php';
+require_once ETB_THEME_DIR . '/includes/enqueue-scripts.php';
+
+
+// Initialize database setup (e.g., on theme activation or admin notice)
+// This is now handled by an admin notice and action in db-setup.php
+
+/**
+ * Function to initialize the email template builder components.
+ */
+function etb_initialize() {
+    // Database table creation is prompted by an admin notice in db-setup.php.
+    // No explicit call to etb_create_custom_table() here unless a different trigger is desired.
+
+    // Initialize AJAX handlers
+    // Ensure the function etb_register_ajax_handlers exists in ajax-handlers.php
+    if (function_exists('etb_register_ajax_handlers')) {
+        etb_register_ajax_handlers();
+    }
+
+    // Initialize script and style enqueuing
+    // Ensure the function etb_register_enqueue_hooks exists in enqueue-scripts.php
+    if (function_exists('etb_register_enqueue_hooks')) {
+        etb_register_enqueue_hooks();
+    }
+
+    // Page template (email-builder/templates/page-template-email-builder.php) is automatically detected by WordPress.
+    // No specific loading logic needed here for it.
+}
+add_action( 'after_setup_theme', 'etb_initialize', 20 ); // Initialize after theme setup
+
+
+// Remove placeholder creation for page template as it's now a fixed file.
+
+// Placeholder for shortcode file content (keeping file for now, but not using)
+if ( ! file_exists( ETB_THEME_DIR . '/includes/shortcode.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/includes/shortcode.php', "<?php\n// Shortcode logic - NOT CURRENTLY USED. Page template is preferred.\nif ( ! defined( 'ABSPATH' ) ) exit;\n?>" );
+}
+
+// Placeholder for ajax handlers file content
+if ( ! file_exists( ETB_THEME_DIR . '/includes/ajax-handlers.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/includes/ajax-handlers.php', "<?php\n// AJAX handlers will go here.\nif ( ! defined( 'ABSPATH' ) ) exit;\n\nfunction etb_register_ajax_handlers() {\n // add_action( 'wp_ajax_...', ... );\n}\n?>" );
+}
+
+// Placeholder for enqueue scripts file content
+if ( ! file_exists( ETB_THEME_DIR . '/includes/enqueue-scripts.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/includes/enqueue-scripts.php', "<?php\n// Script and style enqueuing logic will go here.\nif ( ! defined( 'ABSPATH' ) ) exit;\n\nfunction etb_register_enqueue_hooks(){\n // add_action( 'wp_enqueue_scripts', ... );\n}\n?>" );
+}
+
+
+// Placeholder for assets
+if ( ! is_dir( ETB_THEME_DIR . '/assets/css' ) ) {
+    mkdir( ETB_THEME_DIR . '/assets/css', 0755, true );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/assets/css/email-builder.css' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/assets/css/email-builder.css', "/* Email Builder Styles */\n" );
+}
+
+if ( ! is_dir( ETB_THEME_DIR . '/assets/js' ) ) {
+    mkdir( ETB_THEME_DIR . '/assets/js', 0755, true );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/assets/js/email-builder.js' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/assets/js/email-builder.js', "// Email Builder JS\n(function($) {\n\t'use strict';\n\t$(function() {\n\t\t// Code here\n\t});\n})(jQuery);\n" );
+}
+
+// Placeholder for index.php files
+$index_content = "<?php\n// Silence is golden.\n";
+if ( ! file_exists( ETB_THEME_DIR . '/index.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/index.php', $index_content );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/includes/index.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/includes/index.php', $index_content );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/templates/index.php' ) ) {
+     if ( ! is_dir( ETB_THEME_DIR . '/templates' ) ) { mkdir( ETB_THEME_DIR . '/templates', 0755, true ); }
+    file_put_contents( ETB_THEME_DIR . '/templates/index.php', $index_content );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/assets/index.php' ) ) {
+     if ( ! is_dir( ETB_THEME_DIR . '/assets' ) ) { mkdir( ETB_THEME_DIR . '/assets', 0755, true ); }
+    file_put_contents( ETB_THEME_DIR . '/assets/index.php', $index_content );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/assets/css/index.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/assets/css/index.php', $index_content );
+}
+if ( ! file_exists( ETB_THEME_DIR . '/assets/js/index.php' ) ) {
+    file_put_contents( ETB_THEME_DIR . '/assets/js/index.php', $index_content );
+}
+
+?>

--- a/email-builder/includes/ajax-handlers.php
+++ b/email-builder/includes/ajax-handlers.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * AJAX Handlers for Email Template Builder
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Registers all AJAX action hooks.
+ * Called by etb_initialize()
+ */
+function etb_register_ajax_handlers() {
+    $ajax_actions = array(
+        'load_templates_list',
+        'load_template_data',
+        'save_template',
+        'delete_template',
+        'clone_template'
+    );
+
+    foreach ( $ajax_actions as $action ) {
+        add_action( 'wp_ajax_etb_' . $action, 'etb_ajax_handle_' . $action );
+    }
+}
+
+/**
+ * AJAX Handler: Load list of templates.
+ */
+function etb_ajax_handle_load_templates_list() {
+    check_ajax_referer( 'etb_ajax_nonce', 'nonce' );
+
+    if ( ! current_user_can( 'edit_posts' ) ) { // Basic capability check, adjust if needed
+        wp_send_json_error( array( 'message' => __( 'Permission denied.', 'your-theme-textdomain' ) ), 403 );
+    }
+
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'email_templates';
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+    $templates = $wpdb->get_results( "SELECT id, name FROM {$table_name} ORDER BY name ASC", ARRAY_A );
+
+    if ( $wpdb->last_error ) {
+        wp_send_json_error( array( 'message' => __( 'Error fetching templates: ', 'your-theme-textdomain' ) . $wpdb->last_error ), 500 );
+    } else {
+        wp_send_json_success( $templates );
+    }
+}
+
+/**
+ * AJAX Handler: Load data for a specific template.
+ */
+function etb_ajax_handle_load_template_data() {
+    check_ajax_referer( 'etb_ajax_nonce', 'nonce' );
+
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_send_json_error( array( 'message' => __( 'Permission denied.', 'your-theme-textdomain' ) ), 403 );
+    }
+
+    $template_id = isset( $_POST['template_id'] ) ? absint( $_POST['template_id'] ) : 0;
+
+    if ( ! $template_id ) {
+        wp_send_json_error( array( 'message' => __( 'Invalid template ID.', 'your-theme-textdomain' ) ), 400 );
+    }
+
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'email_templates';
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+    $template_data = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE id = %d", $template_id ), ARRAY_A );
+
+    if ( $wpdb->last_error ) {
+        wp_send_json_error( array( 'message' => __( 'Error fetching template data: ', 'your-theme-textdomain' ) . $wpdb->last_error ), 500 );
+    } elseif ( ! $template_data ) {
+        wp_send_json_error( array( 'message' => __( 'Template not found.', 'your-theme-textdomain' ) ), 404 );
+    } else {
+        // Ensure longtext fields are properly handled (stripslashes if magic quotes were on, though less common now)
+        $template_data['content_en'] = stripslashes($template_data['content_en']);
+        $template_data['content_pt'] = stripslashes($template_data['content_pt']);
+        $template_data['content_es'] = stripslashes($template_data['content_es']);
+        $template_data['sections_order'] = isset($template_data['sections_order']) ? stripslashes($template_data['sections_order']) : null;
+        $template_data['settings'] = isset($template_data['settings']) ? stripslashes($template_data['settings']) : null;
+        wp_send_json_success( $template_data );
+    }
+}
+
+/**
+ * AJAX Handler: Save (Create or Update) a template.
+ */
+function etb_ajax_handle_save_template() {
+    check_ajax_referer( 'etb_ajax_nonce', 'nonce' );
+
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_send_json_error( array( 'message' => __( 'Permission denied.', 'your-theme-textdomain' ) ), 403 );
+    }
+
+    $template_id    = isset( $_POST['template_id'] ) ? absint( $_POST['template_id'] ) : 0;
+    $template_name  = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+
+    // For content, we expect HTML. Using wp_kses_post is a good balance for allowing rich content
+    // while stripping potentially harmful elements if not used carefully.
+    // Consider the implications if users can inject arbitrary script tags if not intended.
+    // For this tool, assuming the generated HTML is mostly safe but applying kses_post as a precaution.
+    $content_en     = isset( $_POST['content_en'] ) ? wp_unslash( $_POST['content_en'] ) : '';
+    $content_pt     = isset( $_POST['content_pt'] ) ? wp_unslash( $_POST['content_pt'] ) : '';
+    $content_es     = isset( $_POST['content_es'] ) ? wp_unslash( $_POST['content_es'] ) : '';
+
+    // For JSON data, ensure it's valid JSON before saving or use appropriate sanitization.
+    // Using sanitize_text_field for now as a basic measure.
+    $sections_order = isset( $_POST['sections_order'] ) ? sanitize_text_field( wp_unslash( $_POST['sections_order'] ) ) : '';
+    $settings       = isset( $_POST['settings'] ) ? sanitize_text_field( wp_unslash( $_POST['settings'] ) ) : '';
+
+    if ( empty( $template_name ) ) {
+        wp_send_json_error( array( 'message' => __( 'Template name cannot be empty.', 'your-theme-textdomain' ) ), 400 );
+    }
+
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'email_templates';
+    $data = array(
+        'name'            => $template_name,
+        'content_en'      => $content_en, // Not using kses_post here to allow full HTML from builder
+        'content_pt'      => $content_pt,
+        'content_es'      => $content_es,
+        'sections_order'  => $sections_order,
+        'settings'        => $settings,
+    );
+    $format = array( '%s', '%s', '%s', '%s', '%s', '%s' );
+
+    if ( $template_id ) { // Update existing
+        $data['updated_at'] = current_time( 'mysql', 1 ); // GMT
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+        $result = $wpdb->update( $table_name, $data, array( 'id' => $template_id ), $format, array( '%d' ) );
+        $new_template_id = $template_id;
+    } else { // Create new
+        $data['created_at'] = current_time( 'mysql', 1 ); // GMT
+         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+        $result = $wpdb->insert( $table_name, $data, $format );
+        $new_template_id = $wpdb->insert_id;
+    }
+
+    if ( false === $result ) {
+        wp_send_json_error( array( 'message' => __( 'Database error: ', 'your-theme-textdomain' ) . $wpdb->last_error ), 500 );
+    } else {
+        wp_send_json_success( array(
+            'message'     => __( 'Template saved successfully.', 'your-theme-textdomain' ),
+            'template_id' => $new_template_id,
+            'name'        => $template_name // Send back the name for UI updates
+        ) );
+    }
+}
+
+
+/**
+ * AJAX Handler: Delete a template.
+ */
+function etb_ajax_handle_delete_template() {
+    check_ajax_referer( 'etb_ajax_nonce', 'nonce' );
+
+    if ( ! current_user_can( 'delete_posts' ) ) { // Or a more specific capability
+        wp_send_json_error( array( 'message' => __( 'Permission denied.', 'your-theme-textdomain' ) ), 403 );
+    }
+
+    $template_id = isset( $_POST['template_id'] ) ? absint( $_POST['template_id'] ) : 0;
+
+    if ( ! $template_id ) {
+        wp_send_json_error( array( 'message' => __( 'Invalid template ID.', 'your-theme-textdomain' ) ), 400 );
+    }
+
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'email_templates';
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+    $result = $wpdb->delete( $table_name, array( 'id' => $template_id ), array( '%d' ) );
+
+    if ( false === $result ) {
+        wp_send_json_error( array( 'message' => __( 'Error deleting template: ', 'your-theme-textdomain' ) . $wpdb->last_error ), 500 );
+    } elseif ( 0 === $result ) {
+        wp_send_json_error( array( 'message' => __( 'Template not found or already deleted.', 'your-theme-textdomain' ) ), 404 );
+    }
+    else {
+        wp_send_json_success( array( 'message' => __( 'Template deleted successfully.', 'your-theme-textdomain' ) ) );
+    }
+}
+
+/**
+ * AJAX Handler: Clone a template.
+ */
+function etb_ajax_handle_clone_template() {
+    check_ajax_referer( 'etb_ajax_nonce', 'nonce' );
+
+    if ( ! current_user_can( 'edit_posts' ) ) { // Capability to create new content
+        wp_send_json_error( array( 'message' => __( 'Permission denied.', 'your-theme-textdomain' ) ), 403 );
+    }
+
+    $template_id_to_clone = isset( $_POST['template_id'] ) ? absint( $_POST['template_id'] ) : 0;
+
+    if ( ! $template_id_to_clone ) {
+        wp_send_json_error( array( 'message' => __( 'Invalid template ID to clone.', 'your-theme-textdomain' ) ), 400 );
+    }
+
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'email_templates';
+
+    // Fetch the original template
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+    $original_template = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE id = %d", $template_id_to_clone ), ARRAY_A );
+
+    if ( ! $original_template ) {
+        wp_send_json_error( array( 'message' => __( 'Original template not found.', 'your-theme-textdomain' ) ), 404 );
+    }
+
+    // Prepare data for the new (cloned) template
+    $cloned_data = $original_template;
+    unset( $cloned_data['id'] ); // Remove original ID
+    $cloned_data['name'] = $original_template['name'] . ' ' . __( '(Copy)', 'your-theme-textdomain' );
+    $cloned_data['created_at'] = current_time( 'mysql', 1 );
+    $cloned_data['updated_at'] = current_time( 'mysql', 1 );
+
+    // Define formats for each column type
+    $format = array(
+        '%s', // name
+        '%s', // content_en
+        '%s', // content_pt
+        '%s', // content_es
+        '%s', // sections_order
+        '%s', // settings
+        '%s', // created_at
+        '%s'  // updated_at
+    );
+
+
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+    $result = $wpdb->insert( $table_name, $cloned_data, $format );
+    $new_template_id = $wpdb->insert_id;
+
+    if ( false === $result ) {
+        wp_send_json_error( array( 'message' => __( 'Error cloning template: ', 'your-theme-textdomain' ) . $wpdb->last_error ), 500 );
+    } else {
+        // Fetch the newly cloned template to return its full data
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+        $new_template_data = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table_name} WHERE id = %d", $new_template_id ), ARRAY_A );
+        if ($new_template_data) {
+            $new_template_data['content_en'] = stripslashes($new_template_data['content_en']);
+            $new_template_data['content_pt'] = stripslashes($new_template_data['content_pt']);
+            $new_template_data['content_es'] = stripslashes($new_template_data['content_es']);
+            $new_template_data['sections_order'] = isset($new_template_data['sections_order']) ? stripslashes($new_template_data['sections_order']) : null;
+            $new_template_data['settings'] = isset($new_template_data['settings']) ? stripslashes($new_template_data['settings']) : null;
+        }
+
+
+        wp_send_json_success( array(
+            'message'     => __( 'Template cloned successfully.', 'your-theme-textdomain' ),
+            'new_template' => $new_template_data // Send full data of the new clone
+        ) );
+    }
+}
+
+?>

--- a/email-builder/includes/db-setup.php
+++ b/email-builder/includes/db-setup.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Database setup for Email Template Builder.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Creates the custom database table for email templates.
+ * This function should be called appropriately during theme setup.
+ * For example, on 'after_switch_theme' or via a theme options page.
+ */
+function etb_create_custom_table() {
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'email_templates'; // Consistent table name
+    $charset_collate = $wpdb->get_charset_collate();
+
+    // Check if table already exists or if the version is old
+    $current_db_version = get_option( 'etb_db_version', '0' );
+
+    // Only proceed if table needs to be created or updated
+    // For simplicity, we'll run dbDelta if version doesn't match.
+    // More complex migration logic would be needed for schema changes in existing tables.
+    if ( version_compare( $current_db_version, ETB_VERSION, '<' ) ) {
+        $sql = "CREATE TABLE $table_name (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            name varchar(255) NOT NULL,
+            content_en longtext DEFAULT NULL,
+            content_pt longtext DEFAULT NULL,
+            content_es longtext DEFAULT NULL,
+            sections_order text DEFAULT NULL,
+            settings text DEFAULT NULL,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+
+        // Check for errors (dbDelta can be a bit tricky)
+        if (empty($wpdb->last_error)) {
+            update_option( 'etb_db_version', ETB_VERSION );
+            update_option( 'etb_db_installed', ETB_VERSION ); // Simple flag
+            // You might want to add an admin notice here for success
+        } else {
+            // Log error or add an admin notice for failure
+            // error_log("ETB DB Error: " . $wpdb->last_error);
+        }
+    }
+}
+
+/**
+ * Example of how to trigger table creation.
+ * You might want a more robust way, e.g., a button in theme options.
+ * 'after_switch_theme' runs only once when the theme is activated.
+ */
+// add_action( 'after_switch_theme', 'etb_create_custom_table' );
+
+/**
+ * You could also add an admin notice with a button to trigger the setup.
+ * Example:
+ */
+function etb_admin_notice_db_setup() {
+    if (get_option('etb_db_installed') !== ETB_VERSION && current_user_can('manage_options')) {
+        $setup_url = wp_nonce_url(add_query_arg('etb_action', 'setup_db'), 'etb_setup_db_nonce');
+        echo '<div class="notice notice-warning is-dismissible">';
+        echo '<p>' . sprintf( __('The Email Template Builder needs to set up its database table. <a href="%s">Click here to set it up.</a>', 'your-theme-textdomain'), esc_url($setup_url) ) . '</p>';
+        echo '</div>';
+    }
+}
+add_action( 'admin_notices', 'etb_admin_notice_db_setup' );
+
+function etb_handle_db_setup_action() {
+    if (isset($_GET['etb_action']) && $_GET['etb_action'] === 'setup_db' && isset($_GET['_wpnonce'])) {
+        if (wp_verify_nonce($_GET['_wpnonce'], 'etb_setup_db_nonce') && current_user_can('manage_options')) {
+            etb_create_custom_table();
+            // Redirect to avoid re-running on refresh, or just let the notice disappear.
+            wp_redirect(remove_query_arg(array('etb_action', '_wpnonce')));
+            exit;
+        }
+    }
+}
+add_action( 'admin_init', 'etb_handle_db_setup_action' );
+
+?>

--- a/email-builder/includes/enqueue-scripts.php
+++ b/email-builder/includes/enqueue-scripts.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Enqueue scripts and styles for the Email Template Builder.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Enqueues scripts and styles for the email template builder.
+ *
+ * This function is hooked into 'wp_enqueue_scripts'.
+ * It only enqueues assets if the current page is using the email builder page template.
+ */
+function etb_enqueue_assets() {
+    // Check if we are on the correct page template.
+    // The template filename can be 'page-template-email-builder.php' (if in theme root)
+    // or 'templates/page-template-email-builder.php' or 'email-builder/templates/page-template-email-builder.php'
+    // get_page_template_slug() returns the path relative to the theme root.
+    $template_slug = get_page_template_slug();
+    $expected_slug = 'email-builder/templates/page-template-email-builder.php';
+
+    if ( $template_slug === $expected_slug ) {
+
+        // Enqueue styles
+        wp_enqueue_style(
+            'jquery-ui-css',
+            'https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css', // Using a specific stable version
+            array(),
+            '1.13.2'
+        );
+        wp_enqueue_style(
+            'etb-styles', // Handle for the builder's main CSS
+            ETB_THEME_URL . '/assets/css/email-builder.css',
+            array('jquery-ui-css'), // Depends on jQuery UI styles
+            ETB_VERSION
+        );
+
+        // Enqueue scripts
+        wp_enqueue_script( 'jquery' ); // Ensure jQuery is loaded (it's a WP dependency)
+        wp_enqueue_script( 'jquery-ui-core' );
+        wp_enqueue_script( 'jquery-ui-tabs' ); // Specifically for the tabs
+        wp_enqueue_script( 'jquery-ui-sortable' );
+        wp_enqueue_script( 'jquery-ui-dialog' ); // For potential modal dialogs
+
+        wp_enqueue_script(
+            'etb-script', // Handle for the builder's main JS
+            ETB_THEME_URL . '/assets/js/email-builder.js',
+            array( 'jquery', 'jquery-ui-core', 'jquery-ui-tabs', 'jquery-ui-sortable', 'jquery-ui-dialog' ),
+            ETB_VERSION,
+            true // Load in footer
+        );
+
+        // Prepare data to pass to the JavaScript file
+        $localized_data = array(
+            'ajax_url' => admin_url( 'admin-ajax.php' ),
+            'nonce'    => wp_create_nonce( 'etb_ajax_nonce' ), // Nonce for securing AJAX requests
+                // It's crucial for the theme developer to set 'etb_default_template_html' option
+                // with the base email HTML structure, marked up with data-etb-* attributes.
+                'initial_template_html' => stripslashes(get_option('etb_default_template_html', '')),
+                'text_strings' => array(
+                'confirm_delete' => __('Are you sure you want to delete this template? This action cannot be undone.', 'your-theme-textdomain'),
+                'error_saving' => __('An error occurred while saving the template. Please try again.', 'your-theme-textdomain'),
+                'template_loaded' => __('Template loaded successfully.', 'your-theme-textdomain'),
+                'template_saved' => __('Template saved successfully.', 'your-theme-textdomain'),
+                'template_deleted' => __('Template deleted successfully.', 'your-theme-textdomain'),
+                'template_cloned' => __('Template cloned successfully. You are now editing the clone.', 'your-theme-textdomain'),
+                'select_template_to_load' => __('Please select a template to load.', 'your-theme-textdomain'),
+                'select_template_to_clone' => __('Please select a template to clone.', 'your-theme-textdomain'),
+                'select_template_to_delete' => __('Please select a template to delete.', 'your-theme-textdomain'),
+                'enter_template_name' => __('Please enter a name for the new template.', 'your-theme-textdomain'),
+                    'no_changes_to_save' => __('No changes to save.', 'your-theme-textdomain'),
+                    'no_template_to_export' => __('Load or create a template to export.', 'your-theme-textdomain'),
+                    'template_exported' => __('Template HTML exported.', 'your-theme-textdomain'),
+                    'no_changes_to_reset' => __('No unsaved changes to reset.', 'your-theme-textdomain'),
+                    'confirm_reset_changes' => __('Are you sure you want to discard unsaved changes?', 'your-theme-textdomain'),
+                    'changes_reset' => __('Changes have been reset.', 'your-theme-textdomain'),
+                )
+            )
+        );
+
+        wp_localize_script(
+            'etb-script',      // Handle of the script to attach data to
+            'etb_ajax_obj',    // Object name in JavaScript
+            $localized_data    // Data to pass
+        );
+    }
+}
+
+/**
+ * Registers the hook for enqueuing assets.
+ * This function is called by etb_initialize() in email-builder.php.
+ */
+function etb_register_enqueue_hooks() {
+    add_action( 'wp_enqueue_scripts', 'etb_enqueue_assets' );
+}
+
+// The main email-builder.php file calls etb_register_enqueue_hooks()
+// within its etb_initialize() function, which is hooked to 'after_setup_theme'.
+?>

--- a/email-builder/templates/page-template-email-builder.php
+++ b/email-builder/templates/page-template-email-builder.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Template Name: Email Template Builder
+ *
+ * This is the template that displays the Email Template Builder application.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Ensure user is logged in
+if ( ! is_user_logged_in() ) {
+    get_header();
+    echo '<div style="padding: 20px; text-align: center;">'; // Added text-align for better presentation
+    echo '<h1>' . esc_html__( 'Access Denied', 'your-theme-textdomain' ) . '</h1>';
+    echo '<p>' . esc_html__( 'You must be logged in to use the Email Template Builder. Please log in and try again.', 'your-theme-textdomain' ) . '</p>';
+    // Optionally, display a login form or link to login page
+    echo '<p><a href="' . esc_url(wp_login_url(get_permalink())) . '" class="button button-primary">' . esc_html__('Log In', 'your-theme-textdomain') . '</a></p>';
+    // Example of wp_login_form():
+    // if ( !is_user_logged_in() ) {
+    //     wp_login_form(array('redirect' => get_permalink()));
+    // }
+    echo '</div>';
+    get_footer();
+    return; // Stop further execution
+}
+
+// If logged in, display the builder.
+// Consider using a more minimal header/footer if your theme provides one for "blank slate" or "canvas" pages.
+get_header();
+?>
+
+<div id="etb-app-container" class="etb-app-theme-container">
+    <div id="etb-sidebar-panel">
+        <div class="etb-sidebar-header">
+            <h2><?php esc_html_e( 'Template Controls', 'your-theme-textdomain' ); ?></h2>
+        </div>
+        <div id="etb-template-management-section">
+            <h3><?php esc_html_e( 'Manage Templates', 'your-theme-textdomain' ); ?></h3>
+            <div class="etb-template-actions">
+                <label for="etb-template-select" class="screen-reader-text"><?php esc_html_e( 'Select a Template', 'your-theme-textdomain' ); ?></label>
+                <select id="etb-template-select">
+                    <option value=""><?php esc_html_e( '-- Select a Template --', 'your-theme-textdomain' ); ?></option>
+                    <!-- Template options will be populated by JS -->
+                </select>
+            </div>
+            <div class="etb-template-buttons">
+                <button id="etb-load-template-button" class="button" disabled><?php esc_html_e( 'Load', 'your-theme-textdomain' ); ?></button>
+                <button id="etb-create-new-template-button" class="button button-secondary"><?php esc_html_e( 'Create New', 'your-theme-textdomain' ); ?></button>
+                <button id="etb-clone-template-button" class="button" disabled><?php esc_html_e( 'Clone', 'your-theme-textdomain' ); ?></button>
+                <button id="etb-delete-template-button" class="button button-danger" disabled><?php esc_html_e( 'Delete', 'your-theme-textdomain' ); ?></button>
+            </div>
+        </div>
+        <div id="etb-current-template-name-section" style="display:none;">
+             <label for="etb-current-template-name"><?php esc_html_e( 'Template Name:', 'your-theme-textdomain' ); ?></label>
+             <input type="text" id="etb-current-template-name" placeholder="<?php esc_attr_e( 'Enter template name', 'your-theme-textdomain' ); ?>" />
+        </div>
+        <div id="etb-controls-section">
+            <h4><?php esc_html_e( 'Editable Sections', 'your-theme-textdomain' ); ?></h4>
+            <div id="etb-sortable-items-container">
+                <!-- Dynamic controls and sortable sections will be loaded here by JS -->
+                <p class="etb-no-controls-message"><?php esc_html_e( 'Select or create a template, then load its structure to see editable sections.', 'your-theme-textdomain' ); ?></p>
+            </div>
+        </div>
+    </div>
+
+    <div id="etb-main-preview-area">
+        <div id="etb-preview-tabs">
+            <ul class="etb-preview-tab-nav">
+                <li><a href="#etb-preview-en"><?php esc_html_e( 'EN', 'your-theme-textdomain' ); ?></a></li>
+                <li><a href="#etb-preview-pt"><?php esc_html_e( 'PT', 'your-theme-textdomain' ); ?></a></li>
+                <li><a href="#etb-preview-es"><?php esc_html_e( 'ES', 'your-theme-textdomain' ); ?></a></li>
+            </ul>
+            <div id="etb-preview-en" class="etb-preview-tab-content">
+                <iframe id="etb-iframe-en" title="<?php esc_attr_e( 'English Preview', 'your-theme-textdomain' ); ?>"></iframe>
+            </div>
+            <div id="etb-preview-pt" class="etb-preview-tab-content">
+                <iframe id="etb-iframe-pt" title="<?php esc_attr_e( 'Portuguese Preview', 'your-theme-textdomain' ); ?>"></iframe>
+            </div>
+            <div id="etb-preview-es" class="etb-preview-tab-content">
+                <iframe id="etb-iframe-es" title="<?php esc_attr_e( 'Spanish Preview', 'your-theme-textdomain' ); ?>"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <div id="etb-action-bar">
+        <button id="etb-save-template-button" class="button button-primary" disabled><?php esc_html_e( 'Save Template', 'your-theme-textdomain' ); ?></button>
+        <button id="etb-export-html-button" class="button" disabled><?php esc_html_e( 'Export HTML', 'your-theme-textdomain' ); ?></button>
+        <button id="etb-reset-template-button" class="button" disabled><?php esc_html_e( 'Reset Changes', 'your-theme-textdomain' ); ?></button>
+    </div>
+</div>
+
+<?php
+// It's important that this template calls wp_footer() for scripts to be loaded.
+get_footer();
+?>

--- a/email-template-builder.php
+++ b/email-template-builder.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Plugin Name: Email Template Builder
+ * Description: A custom web app to build and manage email templates using jQuery, embedded in a WordPress page.
+ * Version: 1.0.0
+ * Author: Jules
+ * Author URI: https://example.com
+ * License: GPL-2.0+
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain: email-template-builder
+ * Domain Path: /languages
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Define constants
+ */
+define( 'ETB_VERSION', '1.0.0' );
+define( 'ETB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'ETB_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'ETB_PLUGIN_FILE', __FILE__ );
+
+/**
+ * The code that runs during plugin activation.
+ * This action is documented in includes/class-email-template-builder-activator.php
+ */
+function activate_email_template_builder() {
+    require_once ETB_PLUGIN_DIR . 'includes/class-email-template-builder-activator.php';
+    Email_Template_Builder_Activator::activate();
+}
+
+/**
+ * The code that runs during plugin deactivation.
+ * This action is documented in includes/class-email-template-builder-deactivator.php
+ */
+function deactivate_email_template_builder() {
+    require_once ETB_PLUGIN_DIR . 'includes/class-email-template-builder-deactivator.php';
+    Email_Template_Builder_Deactivator::deactivate();
+}
+
+register_activation_hook( __FILE__, 'activate_email_template_builder' );
+register_deactivation_hook( __FILE__, 'deactivate_email_template_builder' );
+
+/**
+ * The core plugin class that is used to define internationalization,
+ * admin-specific hooks, and public-facing site hooks.
+ */
+require ETB_PLUGIN_DIR . 'includes/class-email-template-builder.php';
+
+/**
+ * Begins execution of the plugin.
+ *
+ * Since everything within the plugin is registered via hooks,
+ * then kicking off the plugin from this point in the file does
+ * not affect the page life cycle.
+ *
+ * @since    1.0.0
+ */
+function run_email_template_builder() {
+
+    $plugin = new Email_Template_Builder();
+    $plugin->run();
+
+}
+run_email_template_builder();

--- a/includes/class-email-template-builder-activator.php
+++ b/includes/class-email-template-builder-activator.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Fired during plugin activation.
+ *
+ * This class defines all code necessary to run during the plugin's activation.
+ *
+ * @since      1.0.0
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ * @author     Jules <your-email@example.com>
+ */
+class Email_Template_Builder_Activator {
+
+    /**
+     * Short Description. (use period)
+     *
+     * Long Description.
+     *
+     * @since    1.0.0
+     */
+    public static function activate() {
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'email_templates';
+        $charset_collate = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE $table_name (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            name varchar(255) NOT NULL,
+            content_en longtext DEFAULT NULL,
+            content_pt longtext DEFAULT NULL,
+            content_es longtext DEFAULT NULL,
+            sections_order text DEFAULT NULL,
+            settings text DEFAULT NULL,
+            created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+
+        // Add an option to store the plugin version, useful for future upgrades/migrations
+        add_option( 'etb_db_version', ETB_VERSION );
+    }
+
+}

--- a/includes/class-email-template-builder-deactivator.php
+++ b/includes/class-email-template-builder-deactivator.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Fired during plugin deactivation.
+ *
+ * This class defines all code necessary to run during the plugin's deactivation.
+ *
+ * @since      1.0.0
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ * @author     Jules <your-email@example.com>
+ */
+class Email_Template_Builder_Deactivator {
+
+    /**
+     * Short Description. (use period)
+     *
+     * Long Description.
+     *
+     * @since    1.0.0
+     */
+    public static function deactivate() {
+        // We can add any deactivation logic here if needed,
+        // e.g., removing scheduled cron jobs.
+        // Table deletion will be handled in uninstall.php if desired.
+    }
+
+}

--- a/includes/class-email-template-builder-i18n.php
+++ b/includes/class-email-template-builder-i18n.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Define the internationalization functionality
+ *
+ * Loads and defines the internationalization files for this plugin
+ * so that it is ready for translation.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ */
+
+/**
+ * Define the internationalization functionality.
+ *
+ * Loads and defines the internationalization files for this plugin
+ * so that it is ready for translation.
+ *
+ * @since      1.0.0
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ * @author     Jules <your-email@example.com>
+ */
+class Email_Template_Builder_i18n {
+
+    /**
+     * Load the plugin text domain for translation.
+     *
+     * @since    1.0.0
+     */
+    public function load_plugin_textdomain() {
+
+        load_plugin_textdomain(
+            'email-template-builder',
+            false,
+            dirname( dirname( plugin_basename( ETB_PLUGIN_FILE ) ) ) . '/languages/'
+        );
+
+    }
+
+}

--- a/includes/class-email-template-builder-loader.php
+++ b/includes/class-email-template-builder-loader.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Register all actions and filters for the plugin
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ */
+
+/**
+ * Register all actions and filters for the plugin.
+ *
+ * Maintain a list of all hooks that are registered throughout
+ * the plugin, and register them with the WordPress API. Call the
+ * run function to execute the list of actions and filters.
+ *
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ * @author     Jules <your-email@example.com>
+ */
+class Email_Template_Builder_Loader {
+
+    /**
+     * The array of actions registered with WordPress.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      array    $actions    The actions registered with WordPress to fire when the plugin loads.
+     */
+    protected $actions;
+
+    /**
+     * The array of filters registered with WordPress.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      array    $filters    The filters registered with WordPress to fire when the plugin loads.
+     */
+    protected $filters;
+
+    /**
+     * The array of shortcodes registered with WordPress.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      array    $shortcodes    The shortcodes registered with WordPress to fire when the plugin loads.
+     */
+    protected $shortcodes;
+
+
+    /**
+     * Initialize the collections used to maintain the actions and filters.
+     *
+     * @since    1.0.0
+     */
+    public function __construct() {
+
+        $this->actions = array();
+        $this->filters = array();
+        $this->shortcodes = array();
+
+    }
+
+    /**
+     * Add a new action to the collection to be registered with WordPress.
+     *
+     * @since    1.0.0
+     * @param    string               $hook             The name of the WordPress action that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the action is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
+     * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+     */
+    public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->actions = $this->add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
+    }
+
+    /**
+     * Add a new filter to the collection to be registered with WordPress.
+     *
+     * @since    1.0.0
+     * @param    string               $hook             The name of the WordPress filter that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
+     * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+     */
+    public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+    }
+
+    /**
+     * Add a new shortcode to the collection to be registered with WordPress.
+     *
+     * @since    1.0.0
+     * @param    string               $tag             The name of the WordPress shortcode that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the shortcode is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     */
+    public function add_shortcode( $tag, $component, $callback ) {
+        $this->shortcodes = $this->add_s( $this->shortcodes, $tag, $component, $callback );
+    }
+
+
+    /**
+     * A utility function that is used to register the actions and hooks into a single
+     * collection.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @param    array                $hooks            The collection of hooks that is being registered (that is, actions or filters).
+     * @param    string               $hook             The name of the WordPress hook that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @param    int                  $priority         The priority at which the function should be fired.
+     * @param    int                  $accepted_args    The number of arguments that should be passed to the $callback.
+     * @return   array                                  The collection of actions and filters registered with WordPress.
+     */
+    private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
+
+        $hooks[] = array(
+            'hook'          => $hook,
+            'component'     => $component,
+            'callback'      => $callback,
+            'priority'      => $priority,
+            'accepted_args' => $accepted_args
+        );
+
+        return $hooks;
+
+    }
+
+    /**
+     * A utility function that is used to register the shortcodes into a single
+     * collection.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @param    array                $shortcodes       The collection of shortcodes that is being registered.
+     * @param    string               $tag             The name of the WordPress shortcode tag.
+     * @param    object               $component        A reference to the instance of the object on which the shortcode callback is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @return   array                                  The collection of shortcodes registered with WordPress.
+     */
+    private function add_s( $shortcodes, $tag, $component, $callback ) {
+
+        $shortcodes[] = array(
+            'tag'          => $tag,
+            'component'     => $component,
+            'callback'      => $callback,
+        );
+
+        return $shortcodes;
+
+    }
+
+
+    /**
+     * Register the filters and actions with WordPress.
+     *
+     * @since    1.0.0
+     */
+    public function run() {
+
+        foreach ( $this->filters as $hook ) {
+            add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+
+        foreach ( $this->actions as $hook ) {
+            add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+
+        foreach ( $this->shortcodes as $hook ) {
+            add_shortcode( $hook['tag'], array( $hook['component'], $hook['callback'] ) );
+        }
+    }
+}

--- a/includes/class-email-template-builder.php
+++ b/includes/class-email-template-builder.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * The file that defines the core plugin class
+ *
+ * A class definition that includes attributes and functions used across both the
+ * public-facing side of the site and the admin area.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ */
+
+/**
+ * The core plugin class.
+ *
+ * This is used to define internationalization, admin-specific hooks, and
+ * public-facing site hooks.
+ *
+ * Also NTS:
+ * - main plugin file: email-template-builder.php
+ * - loader: includes/class-email-template-builder-loader.php (will create this)
+ * - public hooks: public/class-email-template-builder-public.php (will create this)
+ * - admin hooks (if any needed beyond CPT): admin/class-email-template-builder-admin.php (will create this)
+ *
+ * @since      1.0.0
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/includes
+ * @author     Jules <your-email@example.com>
+ */
+class Email_Template_Builder {
+
+    /**
+     * The loader that's responsible for maintaining and registering all hooks that power
+     * the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      Email_Template_Builder_Loader    $loader    Maintains and registers all hooks for the plugin.
+     */
+    protected $loader;
+
+    /**
+     * The unique identifier of this plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string    $plugin_name    The string used to uniquely identify this plugin.
+     */
+    protected $plugin_name;
+
+    /**
+     * The current version of the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string    $version    The current version of the plugin.
+     */
+    protected $version;
+
+    /**
+     * Define the core functionality of the plugin.
+     *
+     * Set the plugin name and the plugin version that can be used throughout the plugin.
+     * Load the dependencies, define the locale, and set the hooks for the admin area and
+     * the public-facing side of the site.
+     *
+     * @since    1.0.0
+     */
+    public function __construct() {
+        if ( defined( 'ETB_VERSION' ) ) {
+            $this->version = ETB_VERSION;
+        } else {
+            $this->version = '1.0.0';
+        }
+        $this->plugin_name = 'email-template-builder';
+
+        $this->load_dependencies();
+        $this->set_locale();
+        // $this->define_admin_hooks(); // We might not need admin-specific hooks if it's all frontend
+        $this->define_public_hooks();
+    }
+
+    /**
+     * Load the required dependencies for this plugin.
+     *
+     * Include the following files that make up the plugin:
+     *
+     * - Email_Template_Builder_Loader. Orchestrates the hooks of the plugin.
+     * - Email_Template_Builder_i18n. Defines internationalization functionality.
+     * - Email_Template_Builder_Admin. Defines all hooks for the admin area.
+     * - Email_Template_Builder_Public. Defines all hooks for the public side of the site.
+     *
+     * Create an instance of the loader which will be used to register the hooks
+     * with WordPress.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function load_dependencies() {
+
+        /**
+         * The class responsible for orchestrating the actions and filters of the
+         * core plugin.
+         */
+        require_once ETB_PLUGIN_DIR . 'includes/class-email-template-builder-loader.php';
+
+        /**
+         * The class responsible for defining internationalization functionality
+         * of the plugin.
+         */
+        require_once ETB_PLUGIN_DIR . 'includes/class-email-template-builder-i18n.php';
+
+        /**
+         * The class responsible for defining all actions that occur in the admin area.
+         * We might not need this if the app is purely frontend.
+         */
+        // require_once ETB_PLUGIN_DIR . 'admin/class-email-template-builder-admin.php';
+
+        /**
+         * The class responsible for defining all actions that occur in the public-facing
+         * side of the site.
+         */
+        require_once ETB_PLUGIN_DIR . 'public/class-email-template-builder-public.php';
+
+        $this->loader = new Email_Template_Builder_Loader();
+
+    }
+
+    /**
+     * Define the locale for this plugin for internationalization.
+     *
+     * Uses the Email_Template_Builder_i18n class in order to set the domain and to register the hook
+     * with WordPress.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function set_locale() {
+
+        $plugin_i18n = new Email_Template_Builder_i18n();
+
+        $this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+
+    }
+
+    /**
+     * Register all of the hooks related to the admin area functionality
+     * of the plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    // private function define_admin_hooks() {
+        // $plugin_admin = new Email_Template_Builder_Admin( $this->get_plugin_name(), $this->get_version() );
+        // This is where we would add admin-specific actions and filters.
+        // For example, if we needed a settings page.
+        // $this->loader->add_action( 'admin_menu', $plugin_admin, 'add_options_page' );
+        // $this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+    // }
+
+    /**
+     * Register all of the hooks related to the public-facing functionality
+     * of the plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function define_public_hooks() {
+
+        $plugin_public = new Email_Template_Builder_Public( $this->get_plugin_name(), $this->get_version() );
+
+        $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+        $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+
+        // Add shortcode
+        $this->loader->add_shortcode( 'email_template_builder', $plugin_public, 'display_email_template_builder' );
+
+        // AJAX handlers for loading and saving templates
+        $this->loader->add_action( 'wp_ajax_etb_load_templates', $plugin_public, 'ajax_load_templates' );
+        $this->loader->add_action( 'wp_ajax_etb_save_template', $plugin_public, 'ajax_save_template' );
+        $this->loader->add_action( 'wp_ajax_etb_delete_template', $plugin_public, 'ajax_delete_template' );
+        $this->loader->add_action( 'wp_ajax_etb_clone_template', $plugin_public, 'ajax_clone_template' );
+        // Note: For AJAX actions available to logged-out users, use wp_ajax_nopriv_action_name as well.
+        // Since this is for logged-in users only, wp_ajax_ is sufficient.
+    }
+
+    /**
+     * Run the loader to execute all of the hooks with WordPress.
+     *
+     * @since    1.0.0
+     */
+    public function run() {
+        $this->loader->run();
+    }
+
+    /**
+     * The name of the plugin used to uniquely identify it within the context of
+     * WordPress and to define internationalization functionality.
+     *
+     * @since     1.0.0
+     * @return    string    The name of the plugin.
+     */
+    public function get_plugin_name() {
+        return $this->plugin_name;
+    }
+
+    /**
+     * The reference to the class that orchestrates the hooks with the plugin.
+     *
+     * @since     1.0.0
+     * @return    Email_Template_Builder_Loader    Orchestrates the hooks of the plugin.
+     */
+    public function get_loader() {
+        return $this->loader;
+    }
+
+    /**
+     * Retrieve the version number of the plugin.
+     *
+     * @since     1.0.0
+     * @return    string    The version number of the plugin.
+     */
+    public function get_version() {
+        return $this->version;
+    }
+
+}

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/languages/email-template-builder.pot
+++ b/languages/email-template-builder.pot
@@ -1,0 +1,34 @@
+# Copyright (C) 2024 Your Name
+# This file is distributed under the GPL-2.0+.
+msgid ""
+msgstr ""
+"Project-Id-Version: Email Template Builder 1.0.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/email-template-builder\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2024-07-29T10:00:00+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.x.x\n"
+"X-Domain: email-template-builder\n"
+
+#. Plugin Name of the plugin/theme
+msgid "Email Template Builder"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid "A custom web app to build and manage email templates using jQuery, embedded in a WordPress page."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Jules"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "https://example.com"
+msgstr ""
+
+msgid "You must be logged in to use the Email Template Builder."
+msgstr ""

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/public/class-email-template-builder-public.php
+++ b/public/class-email-template-builder-public.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * The public-facing functionality of the plugin.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/public
+ */
+
+/**
+ * The public-facing functionality of the plugin.
+ *
+ * Defines the plugin name, version, and two examples hooks for how to
+ * enqueue the public-facing stylesheet and JavaScript.
+ *
+ * @package    Email_Template_Builder
+ * @subpackage Email_Template_Builder/public
+ * @author     Jules <your-email@example.com>
+ */
+class Email_Template_Builder_Public {
+
+    /**
+     * The ID of this plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @var      string    $plugin_name    The ID of this plugin.
+     */
+    private $plugin_name;
+
+    /**
+     * The version of this plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @var      string    $version    The current version of this plugin.
+     */
+    private $version;
+
+    /**
+     * Initialize the class and set its properties.
+     *
+     * @since    1.0.0
+     * @param      string    $plugin_name       The name of the plugin.
+     * @param      string    $version    The version of this plugin.
+     */
+    public function __construct( $plugin_name, $version ) {
+
+        $this->plugin_name = $plugin_name;
+        $this->version = $version;
+
+    }
+
+    /**
+     * Register the stylesheets for the public-facing side of the site.
+     *
+     * @since    1.0.0
+     */
+    public function enqueue_styles() {
+        // Only enqueue if the shortcode is present or on the specific page template
+        // This check will be more robust later
+        if ( is_singular() && has_shortcode( get_post_field('post_content', get_the_ID()), 'email_template_builder' ) ) {
+            wp_enqueue_style( $this->plugin_name, ETB_PLUGIN_URL . 'public/css/email-template-builder-public.css', array(), $this->version, 'all' );
+            // Enqueue jQuery UI styles - using a CDN for now, can be bundled later.
+            wp_enqueue_style( 'jquery-ui-css', 'https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css', array(), '1.13.2' );
+        }
+    }
+
+    /**
+     * Register the JavaScript for the public-facing side of the site.
+     *
+     * @since    1.0.0
+     */
+    public function enqueue_scripts() {
+        // Only enqueue if the shortcode is present or on the specific page template
+        if ( is_singular() && has_shortcode( get_post_field('post_content', get_the_ID()), 'email_template_builder' ) ) {
+            wp_enqueue_script( 'jquery' ); // Ensure jQuery is loaded
+            wp_enqueue_script( 'jquery-ui-core' );
+            wp_enqueue_script( 'jquery-ui-sortable' );
+            wp_enqueue_script( 'jquery-ui-dialog' ); // For modals if needed
+
+            wp_enqueue_script( $this->plugin_name, ETB_PLUGIN_URL . 'public/js/email-template-builder-public.js', array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-dialog' ), $this->version, true );
+
+            // Localize script for AJAX
+            wp_localize_script( $this->plugin_name, 'etb_ajax_obj', array(
+                'ajax_url' => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'etb_nonce_action' ) // Will be used for security
+            ) );
+        }
+    }
+
+    /**
+     * Callback for the [email_template_builder] shortcode.
+     *
+     * @since    1.0.0
+     * @param array $atts Shortcode attributes.
+     * @return string HTML output for the email template builder.
+     */
+    public function display_email_template_builder( $atts ) {
+        // Check if user is logged in
+        if ( ! is_user_logged_in() ) {
+            return '<p>' . esc_html__( 'You must be logged in to use the Email Template Builder.', 'email-template-builder' ) . '</p>';
+        }
+
+        // Prepare attributes - none defined for now, but good practice
+        // $atts = shortcode_atts( array(), $atts, 'email_template_builder' );
+
+        // Start output buffering
+        ob_start();
+
+        // We will load the HTML structure of the app here in a later step.
+        // For now, a placeholder:
+        echo '<div id="etb-app-container">';
+        echo '  <div id="etb-sidebar-panel">Sidebar controls will go here.</div>';
+        echo '  <div id="etb-main-preview-area">';
+        echo '      <div id="etb-preview-tabs"><ul><li><a href="#etb-preview-en">EN</a></li><li><a href="#etb-preview-pt">PT</a></li><li><a href="#etb-preview-es">ES</a></li></ul>';
+        echo '          <div id="etb-preview-en"><iframe id="etb-iframe-en"></iframe></div>';
+        echo '          <div id="etb-preview-pt"><iframe id="etb-iframe-pt"></iframe></div>';
+        echo '          <div id="etb-preview-es"><iframe id="etb-iframe-es"></iframe></div>';
+        echo '      </div>';
+        echo '  </div>';
+        echo '  <div id="etb-action-bar">Save, Export, Reset buttons will go here.</div>';
+        echo '</div>';
+
+
+        // Get the buffered content
+        $output = ob_get_clean();
+        return $output;
+    }
+
+    /**
+     * AJAX handler for loading templates.
+     * @since 1.0.0
+     */
+    public function ajax_load_templates() {
+        check_ajax_referer( 'etb_nonce_action', 'nonce' );
+        // Logic to load templates from DB will go here
+        wp_send_json_success( array( 'message' => 'Templates would be loaded here.' ) );
+    }
+
+    /**
+     * AJAX handler for saving a template.
+     * @since 1.0.0
+     */
+    public function ajax_save_template() {
+        check_ajax_referer( 'etb_nonce_action', 'nonce' );
+        // Logic to save template to DB will go here
+        // Expected $_POST data: template_id (optional), name, html_en, html_pt, html_es, sections_order, etc.
+        wp_send_json_success( array( 'message' => 'Template would be saved here.', 'data' => $_POST ) );
+    }
+
+    /**
+     * AJAX handler for deleting a template.
+     * @since 1.0.0
+     */
+    public function ajax_delete_template() {
+        check_ajax_referer( 'etb_nonce_action', 'nonce' );
+        // Logic to delete template from DB will go here
+        // Expected $_POST data: template_id
+        wp_send_json_success( array( 'message' => 'Template would be deleted here.', 'data' => $_POST ) );
+    }
+
+    /**
+     * AJAX handler for cloning a template.
+     * @since 1.0.0
+     */
+    public function ajax_clone_template() {
+        check_ajax_referer( 'etb_nonce_action', 'nonce' );
+        // Logic to clone template in DB will go here
+        // Expected $_POST data: template_id_to_clone
+        wp_send_json_success( array( 'message' => 'Template would be cloned here.', 'data' => $_POST ) );
+    }
+
+}

--- a/public/css/email-template-builder-public.css
+++ b/public/css/email-template-builder-public.css
@@ -1,0 +1,97 @@
+/**
+ * All of the CSS for your public-facing functionality should be
+ * included in this file.
+ */
+
+#etb-app-container {
+    display: flex;
+    height: 80vh; /* Adjust as needed */
+    border: 1px solid #ccc;
+    font-family: Arial, sans-serif;
+}
+
+#etb-sidebar-panel {
+    width: 300px; /* Adjust as needed */
+    padding: 15px;
+    border-right: 1px solid #ccc;
+    overflow-y: auto;
+    background-color: #f9f9f9;
+}
+
+#etb-main-preview-area {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+}
+
+#etb-preview-tabs {
+    flex-grow: 1;
+}
+
+#etb-preview-tabs .ui-tabs-nav {
+    padding: 0;
+    border-bottom: 1px solid #ccc;
+}
+#etb-preview-tabs .ui-tabs-nav li {
+    display: inline-block;
+    margin-right: 5px;
+    border: 1px solid #ccc;
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+}
+#etb-preview-tabs .ui-tabs-nav li a {
+    display: block;
+    padding: 10px 15px;
+    text-decoration: none;
+    color: #333;
+}
+#etb-preview-tabs .ui-tabs-nav li.ui-tabs-active {
+    background-color: #fff;
+    border-bottom: 1px solid #fff; /* Cover the bottom border of the container */
+    position: relative;
+    top: 1px;
+}
+#etb-preview-tabs .ui-tabs-panel {
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-top: none; /* Nav provides top border appearance */
+    height: calc(100% - 40px); /* Adjust based on tab nav height */
+    overflow: auto;
+}
+
+#etb-preview-tabs iframe {
+    width: 100%;
+    height: 98%; /* Small adjustment for panel padding */
+    border: none;
+}
+
+
+#etb-action-bar {
+    padding: 10px;
+    border-top: 1px solid #ccc;
+    text-align: right;
+    background-color: #f1f1f1;
+}
+
+#etb-action-bar button {
+    margin-left: 10px;
+    padding: 8px 15px;
+    cursor: pointer;
+}
+
+/* jQuery UI Sortable placeholders */
+.etb-sortable-section {
+    border: 1px dashed #ccc;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: #fff;
+    cursor: move;
+}
+
+.etb-sortable-placeholder {
+    border: 1px dashed #0073aa;
+    background-color: #f0f8ff;
+    height: 50px;
+    margin-bottom: 10px;
+}

--- a/public/css/index.php
+++ b/public/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/public/js/email-template-builder-public.js
+++ b/public/js/email-template-builder-public.js
@@ -1,0 +1,95 @@
+(function( $ ) {
+    'use strict';
+
+    /**
+     * All of the code for your public-facing JavaScript source
+     * should reside in this file.
+     *
+     * Note: It has been assumed that you will write jQuery code here, so the
+     * $ function reference has been prepared for usage within the scope of this
+     * function.
+     *
+     * This external file is loaded jQuery.ready via the plugin loader.
+     */
+
+    $(function() { // Shorthand for $(document).ready()
+
+        console.log('Email Template Builder Public JS Loaded');
+        console.log('AJAX Object:', etb_ajax_obj); // Check if our localized data is available
+
+        // Initialize jQuery UI Tabs
+        if ($('#etb-preview-tabs').length) {
+            $('#etb-preview-tabs').tabs();
+        }
+
+        // Initialize jQuery UI Sortable (example on a placeholder container)
+        if ($('#etb-sidebar-panel').length) { // Check if the panel exists
+            // This will be refined later to target the actual list of sortable sections
+            // For now, making the entire sidebar panel sortable if it had direct children
+            // that were meant to be sortable.
+            // Example: $("#etb-sortable-sections-container").sortable({ ... });
+        }
+
+        // --- Mock AJAX calls for testing ---
+        // These are just to demonstrate the AJAX setup is working.
+        // Replace with actual event handlers (e.g., button clicks) later.
+
+        function testAjaxCalls() {
+            // Example: Load Templates
+            $.ajax({
+                url: etb_ajax_obj.ajax_url,
+                type: 'POST',
+                data: {
+                    action: 'etb_load_templates',
+                    nonce: etb_ajax_obj.nonce
+                },
+                success: function(response) {
+                    if (response.success) {
+                        console.log('Load Templates AJAX success:', response.data.message);
+                    } else {
+                        console.error('Load Templates AJAX error:', response.data);
+                    }
+                },
+                error: function(xhr, status, error) {
+                    console.error('Load Templates AJAX request failed:', error);
+                }
+            });
+
+            // Example: Save Template (mock data)
+            $.ajax({
+                url: etb_ajax_obj.ajax_url,
+                type: 'POST',
+                data: {
+                    action: 'etb_save_template',
+                    nonce: etb_ajax_obj.nonce,
+                    template_name: 'My Test Template',
+                    html_en: '<p>Hello World</p>',
+                    // ... other template data
+                },
+                success: function(response) {
+                    if (response.success) {
+                        console.log('Save Template AJAX success:', response.data.message, response.data.data);
+                    } else {
+                        console.error('Save Template AJAX error:', response.data);
+                    }
+                },
+                error: function(xhr, status, error) {
+                    console.error('Save Template AJAX request failed:', error);
+                }
+            });
+        }
+
+        // Uncomment to run test AJAX calls on load:
+        // testAjaxCalls();
+
+        // More JS for the builder will go here:
+        // - Handling sidebar control changes
+        // - Updating iframes
+        // - Drag and drop functionality
+        // - AJAX for save, load, delete, clone
+        // - Export functionality
+        // - Reset functionality
+
+    }); // End document ready
+
+})( jQuery );

--- a/public/js/index.php
+++ b/public/js/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Email_Template_Builder
+ */
+
+// If uninstall not called from WordPress, then exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Optional: Code to remove custom database table.
+// Uncomment the following lines to delete the custom table when the plugin is uninstalled.
+/*
+global $wpdb;
+$table_name = $wpdb->prefix . 'email_templates';
+$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+delete_option( 'etb_db_version' ); // Also remove the db version option
+*/
+
+// Optional: Code to remove other plugin options if any were added.
+// delete_option( 'etb_some_other_option' );
+
+// Clear any scheduled cron jobs.
+// Example: wp_clear_scheduled_hook( 'my_hourly_event' );
+?>


### PR DESCRIPTION
- Creates a custom database table for storing email templates.
- Provides a custom page template ('Email Template Builder') to host the application, accessible only to logged-in users.
- Implements a jQuery-based interface with a sidebar for controls and template management, and a main preview area with tabs for EN, PT, and ES languages.
- Supports full CRUD (Create, Read, Update, Delete, Clone) for email templates via AJAX.
- Features live preview updates as content is edited.
- Allows drag-and-drop reordering of email sections.
- Handles dynamic variables (e.g., {{name}}) by preserving them.
- Supports translatable labels, with EN as the source and auto-translation to PT/ES fields (manual override possible).
- Action bar includes Save, Export (EN HTML client-side), and Reset Changes functionalities.
- Requires theme developer to set a WordPress option 'etb_default_template_html' with the marked-up base email structure and populate a translation dictionary in PHP for email content.
- Code is organized within an 'email-builder' directory intended for theme integration.